### PR TITLE
Consider opus files as audio

### DIFF
--- a/app/src/main/java/com/simplecity/amp_library/utils/FileHelper.java
+++ b/app/src/main/java/com/simplecity/amp_library/utils/FileHelper.java
@@ -330,7 +330,7 @@ public class FileHelper {
             "aac", "ts", "flac", "mid",
             "xmf", "mxmf", "midi", "rtttl",
             "rtx", "ota", "imy", "ogg",
-            "mkv", "wav"
+            "opus", "mkv", "wav"
     };
 
     /**


### PR DESCRIPTION
#2 

I don't have a build environment around to test this, but there shouldn't be any issues. I can provide a freely-usable opus-file if needed. Or, with `opus-tools` installed, do this to create a test audio file (with no container)

`opusenc --bitrate 192 file.wav file.opus`