### PR TITLE
Unit Test Dependencies & Unit Tests for ShuttleUtils

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -274,6 +274,11 @@ dependencies {
     // /////////////////////////////////////////////////////////////////////////
 
     testCompile libs.junit
+    testCompile libs.mockito
+    testCompile libs.powermock
+    testCompile libs.powermockjunit
+    testCompile libs.robolectric
+    testCompile libs.assertj
     androidTestCompile(libs.espresso) {
         exclude group: 'com.android.support', module: 'support-annotations'
     }

--- a/app/src/androidTest/java/com/simplecity/amp_library/ExampleInstrumentedTest.java
+++ b/app/src/androidTest/java/com/simplecity/amp_library/ExampleInstrumentedTest.java
@@ -1,4 +1,4 @@
-package simplecity.amp_library.test;
+package com.simplecity.amp_library;
 
 import android.content.Context;
 import android.support.test.InstrumentationRegistry;

--- a/app/src/main/java/com/simplecity/amp_library/ShuttleApplication.java
+++ b/app/src/main/java/com/simplecity/amp_library/ShuttleApplication.java
@@ -202,7 +202,7 @@ public class ShuttleApplication extends Application {
     }
 
     public boolean getIsUpgraded() {
-        return isUpgraded;
+        return isUpgraded || BuildConfig.DEBUG;
     }
 
     private void deleteOldResources() {

--- a/app/src/main/java/com/simplecity/amp_library/utils/ShuttleUtils.java
+++ b/app/src/main/java/com/simplecity/amp_library/utils/ShuttleUtils.java
@@ -227,10 +227,6 @@ public final class ShuttleUtils {
 
     public static boolean isUpgraded() {
 
-        if (BuildConfig.DEBUG) {
-            return true;
-        }
-
         if (ShuttleApplication.getInstance().getIsUpgraded()) {
             return true;
         }

--- a/app/src/test/java/com/simplecity/amp_library/ExampleUnitTest.java
+++ b/app/src/test/java/com/simplecity/amp_library/ExampleUnitTest.java
@@ -1,4 +1,4 @@
-package simplecity.amp_library.test;
+package com.simplecity.amp_library;
 
 import org.junit.Test;
 

--- a/app/src/test/java/com/simplecity/amp_library/utils/ShuttleUtilsPowerMockTest.java
+++ b/app/src/test/java/com/simplecity/amp_library/utils/ShuttleUtilsPowerMockTest.java
@@ -1,0 +1,131 @@
+package com.simplecity.amp_library.utils;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+import android.net.wifi.WifiInfo;
+import android.net.wifi.WifiManager;
+import android.preference.PreferenceManager;
+
+import com.simplecity.amp_library.ShuttleApplication;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+
+/**
+ * This is a separate testing class than {@link ShuttleUtilsTest} as PowerMock and Robolectric
+ * can't work together until Robolectric 3.3 is released:
+ * https://github.com/robolectric/robolectric/wiki/Using-PowerMock
+ * <p>
+ * Use the devDebug build variant to run.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({PreferenceManager.class, ShuttleApplication.class, ShuttleUtils.class})
+public class ShuttleUtilsPowerMockTest {
+
+    @Test
+    public void testIsOnlineWifiConnected() {
+        ShuttleApplication mockApplication = mock(ShuttleApplication.class);
+        SharedPreferences mockSharedPreferences = mock(SharedPreferences.class);
+        ConnectivityManager mockConnectivityManager = mock(ConnectivityManager.class);
+        NetworkInfo mockNetworkInfo = mock(NetworkInfo.class);
+
+        mockStatic(PreferenceManager.class);
+        mockStatic(ShuttleApplication.class);
+
+        when(PreferenceManager.getDefaultSharedPreferences(any(Context.class))).thenReturn(mockSharedPreferences);
+        when(ShuttleApplication.getInstance()).thenReturn(mockApplication);
+
+        // Mock the connection to Wi-Fi
+        when(mockApplication.getSystemService(Context.CONNECTIVITY_SERVICE)).thenReturn(mockConnectivityManager);
+        when(mockConnectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI)).thenReturn(mockNetworkInfo);
+        when(mockNetworkInfo.isConnectedOrConnecting()).thenReturn(true);
+
+        // Test when we care about Wi-Fi (and it's connected), regardless of user preference
+        assertThat(ShuttleUtils.isOnline(true)).isTrue();
+
+        // Test when we don't care about Wi-Fi (but it's connected anyway), regardless of user preference
+        assertThat(ShuttleUtils.isOnline(false)).isTrue();
+    }
+
+    @Test
+    public void testIsOnlineCellularConnected() {
+        ShuttleApplication mockApplication = mock(ShuttleApplication.class);
+        SharedPreferences mockSharedPreferences = mock(SharedPreferences.class);
+        ConnectivityManager mockConnectivityManager = mock(ConnectivityManager.class);
+        NetworkInfo mockNetworkInfo = mock(NetworkInfo.class);
+
+        mockStatic(PreferenceManager.class);
+        mockStatic(ShuttleApplication.class);
+
+        when(PreferenceManager.getDefaultSharedPreferences(any(Context.class))).thenReturn(mockSharedPreferences);
+        when(ShuttleApplication.getInstance()).thenReturn(mockApplication);
+
+        // Mock the connection to cellular data, but not Wi-Fi
+        when(mockApplication.getSystemService(Context.CONNECTIVITY_SERVICE)).thenReturn(mockConnectivityManager);
+        when(mockConnectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI)).thenReturn(null);
+        when(mockConnectivityManager.getActiveNetworkInfo()).thenReturn(mockNetworkInfo);
+        when(mockNetworkInfo.isConnectedOrConnecting()).thenReturn(true);
+
+        // Test when we care about Wi-Fi and so does the user (but only cellular is connected)
+        when(mockSharedPreferences.getBoolean(eq("pref_download_wifi_only"), anyBoolean())).thenReturn(true);
+        assertThat(ShuttleUtils.isOnline(true)).isFalse();
+
+        // Test when we care about Wi-Fi, but the user doesn't (and only cellular is connected)
+        when(mockSharedPreferences.getBoolean(eq("pref_download_wifi_only"), anyBoolean())).thenReturn(false);
+        assertThat(ShuttleUtils.isOnline(true)).isTrue();
+
+        // Test when we don't care about Wi-Fi, even if the user does (and only cellular is connected)
+        when(mockSharedPreferences.getBoolean(eq("pref_download_wifi_only"), anyBoolean())).thenReturn(true);
+        assertThat(ShuttleUtils.isOnline(false)).isTrue();
+
+        // Test when we don't care about Wi-Fi and neither does the user (and only cellular is connected)
+        when(mockSharedPreferences.getBoolean(eq("pref_download_wifi_only"), anyBoolean())).thenReturn(false);
+        assertThat(ShuttleUtils.isOnline(false)).isTrue();
+    }
+
+    @Test
+    public void testIsUpgraded() throws Exception {
+        ShuttleApplication mockApplication = mock(ShuttleApplication.class);
+
+        mockStatic(ShuttleApplication.class);
+        when(ShuttleApplication.getInstance()).thenReturn(mockApplication);
+
+        when(mockApplication.getIsUpgraded()).thenReturn(true);
+        assertThat(ShuttleUtils.isUpgraded()).isTrue();
+
+        when(mockApplication.getIsUpgraded()).thenReturn(false);
+        when(mockApplication.getPackageName()).thenReturn("com.simplecity.amp_pro");
+        assertThat(ShuttleUtils.isUpgraded()).isTrue();
+
+        when(mockApplication.getPackageName()).thenReturn("bad.package.name");
+        assertThat(ShuttleUtils.isUpgraded()).isFalse();
+    }
+
+    @Test
+    public void testGetIpAddr() throws Exception {
+        ShuttleApplication mockApplication = mock(ShuttleApplication.class);
+        WifiManager mockWifiManager = mock(WifiManager.class);
+        WifiInfo mockWifiInfo = mock(WifiInfo.class);
+
+        // Setup mocked IP Address of 192.168.1.1
+        mockStatic(ShuttleApplication.class);
+        when(ShuttleApplication.getInstance()).thenReturn(mockApplication);
+        when(mockApplication.getSystemService(Context.WIFI_SERVICE)).thenReturn(mockWifiManager);
+        when(mockWifiManager.getConnectionInfo()).thenReturn(mockWifiInfo);
+        when(mockWifiInfo.getIpAddress()).thenReturn(16885952);
+
+        assertThat(ShuttleUtils.getIpAddr()).isEqualTo("192.168.1.1");
+    }
+}

--- a/app/src/test/java/com/simplecity/amp_library/utils/ShuttleUtilsTest.java
+++ b/app/src/test/java/com/simplecity/amp_library/utils/ShuttleUtilsTest.java
@@ -1,0 +1,131 @@
+package com.simplecity.amp_library.utils;
+
+
+import android.app.Activity;
+import android.content.ActivityNotFoundException;
+import android.content.ContentResolver;
+import android.content.ContentValues;
+import android.content.Context;
+import android.content.Intent;
+import android.database.Cursor;
+import android.net.Uri;
+
+import com.simplecity.amp_library.model.Song;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * This is a separate from {@link ShuttleUtilsPowerMockTest} for the time being as PowerMock and Robolectric
+ * can't work together until Robolectric 3.3 is released:
+ * https://github.com/robolectric/robolectric/wiki/Using-PowerMock
+ * <p>
+ * Use the devDebug build variant to run.
+ */
+@Config(sdk = 23)
+@RunWith(RobolectricTestRunner.class)
+public class ShuttleUtilsTest {
+    @Test
+    public void testOpenShuttleLinkNullInput() throws Exception {
+        Activity mockActivity = mock(Activity.class);
+        String fakePackage = "fake.package.name";
+
+        ShuttleUtils.openShuttleLink(null, null);
+        verify(mockActivity, never()).startActivity(any(Intent.class));
+
+        ShuttleUtils.openShuttleLink(mockActivity, null);
+        verify(mockActivity, never()).startActivity(any(Intent.class));
+
+        ShuttleUtils.openShuttleLink(null, fakePackage);
+        verify(mockActivity, never()).startActivity(any(Intent.class));
+    }
+
+    @Test
+    public void testOpenShuttleLinkMarketLink() throws Exception {
+        Activity mockActivity = mock(Activity.class);
+        String fakePackage = "fake.package.name";
+
+        // Call the method and capture the "fired" intent
+        ShuttleUtils.openShuttleLink(mockActivity, fakePackage);
+        ArgumentCaptor<Intent> intentCaptor = new ArgumentCaptor<>();
+        verify(mockActivity).startActivity(intentCaptor.capture());
+        Intent intent = intentCaptor.getValue();
+
+        // Expecting a non-Amazon configuration
+        assertThat(intent.getAction()).isEqualTo(Intent.ACTION_VIEW);
+        assertThat(intent.getData()).isEqualTo(Uri.parse("market://details?id=" + fakePackage));
+    }
+
+    @Test
+    public void testOpenShuttleLinkWebLink() throws Exception {
+        Activity mockActivity = mock(Activity.class);
+        String fakePackage = "fake.package.name";
+
+        // Setup the mock to throw an ActivityNotFoundException only the first time startActivity is called
+        doThrow(new ActivityNotFoundException()).doNothing().when(mockActivity).startActivity(any(Intent.class));
+
+        // Call the method and capture the "fired" intent
+        ShuttleUtils.openShuttleLink(mockActivity, fakePackage);
+        ArgumentCaptor<Intent> intentCaptor = new ArgumentCaptor<>();
+        verify(mockActivity, times(2)).startActivity(intentCaptor.capture());
+        Intent intent = intentCaptor.getValue();
+
+        // Expecting a non-Amazon configuration
+        assertThat(intent.getAction()).isEqualTo(Intent.ACTION_VIEW);
+        assertThat(intent.getData()).isEqualTo(Uri.parse("https://play.google.com/store/apps/details?id=" + fakePackage));
+    }
+
+    @Test
+    public void testIncrementPlayCount() throws Exception {
+        Context mockContext = mock(Context.class);
+        ContentResolver mockContentResolver = mock(ContentResolver.class);
+        Song fakeSong = new Song(mock(Cursor.class));
+        fakeSong.id = 100L;
+        fakeSong.playCount = 50;
+
+        // getPlayCount has extra logic to conduct SQL Queries, which would be a pain to mock in a test
+        // so, we can use a Spy here in order to use both fake data (above) plus control return behaviors (below)
+        Song spySong = spy(fakeSong);
+        doReturn(50).when(spySong).getPlayCount(any(Context.class));
+
+        when(mockContext.getContentResolver()).thenReturn(mockContentResolver);
+
+        // Setup to perform the method call on a song with no play counts
+        when(mockContentResolver.update(any(Uri.class), any(ContentValues.class), anyString(), any(String[].class))).thenReturn(0);
+
+        // Call the method and capture the ContentValues object
+        ArgumentCaptor<ContentValues> contentValuesCaptor = new ArgumentCaptor<>();
+        ShuttleUtils.incrementPlayCount(mockContext, spySong);
+        verify(mockContentResolver).update(any(Uri.class), contentValuesCaptor.capture(), anyString(), any(String[].class));
+
+        // Check that the values being updated or inserted match the actual song
+        ContentValues values = contentValuesCaptor.getValue();
+        assertThat(values.get("_id")).isEqualTo(100L);
+        assertThat(values.get("play_count")).isEqualTo(51);
+        verify(mockContentResolver).insert(any(Uri.class), eq(values));
+
+        // Next, test what happens with a song that already had play counts (should not cause an insert operation)
+        reset(mockContentResolver);
+        when(mockContentResolver.update(any(Uri.class), contentValuesCaptor.capture(), anyString(), any(String[].class))).thenReturn(1);
+        ShuttleUtils.incrementPlayCount(mockContext, spySong);
+        verify(mockContentResolver, never()).insert(any(Uri.class), any(ContentValues.class));
+    }
+
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -78,7 +78,17 @@ ext.versions = [
         // /////////////////////////////////////////////////////////////////////////
 
         junit                  : "4.12",
-        espressoCore           : "2.2.2"
+        espressoCore           : "2.2.2",
+        assertj                : "3.6.1",
+
+        // Mockito version restriction -- PowerMock does not fully support Mockito2 yet.
+        // https://github.com/powermock/powermock/wiki/Mockito2_maven
+        mockito                : "1.10.19",
+        powermock              : "1.6.6",
+
+        // Future note: PowerMock and Robolectric can't work together until Robolectric 3.3 is released
+        // https://github.com/robolectric/robolectric/wiki/Using-PowerMock
+        robolectric            : "3.2.2"
 ]
 
 ext.gradlePlugins = [
@@ -174,7 +184,17 @@ ext.libs = [
         // Testing
         // /////////////////////////////////////////////////////////////////////////
 
-        //Junit
+        // JUnit
         junit              : "junit:junit:$versions.junit",
-        espresso           : "com.android.support.test.espresso:espresso-core:$versions.espressoCore"
+        // Espresso
+        espresso           : "com.android.support.test.espresso:espresso-core:$versions.espressoCore",
+        // Mockito - https://github.com/mockito/mockito
+        mockito            : "org.mockito:mockito-core:$versions.mockito",
+        // Powermock - https://github.com/powermock/powermock
+        powermock          : "org.powermock:powermock-api-mockito:$versions.powermock",
+        powermockjunit     : "org.powermock:powermock-module-junit4:$versions.powermock",
+        // Robolectric - https://github.com/robolectric/robolectric
+        robolectric        : "org.robolectric:robolectric:$versions.robolectric",
+        // AssertJ - http://joel-costigliola.github.io/assertj/
+        assertj            : "org.assertj:assertj-core:$versions.assertj"
 ]


### PR DESCRIPTION
## Details
Issue: https://github.com/timusus/Shuttle/issues/15 (just a start) :)

Added the dependencies to do unit testing and created unit tests for `ShuttleUtils` as an initial start. The tests show examples of using [Robolectric](https://github.com/robolectric/robolectric), [Mockito](https://github.com/mockito/mockito), [PowerMock](https://github.com/powermock/powermock), and [AssertJ](http://joel-costigliola.github.io/assertj/), which are all pretty standard unit testing libraries.

I used the `devDebug` variant to build & run the tests on. 

`ShuttleUtils` is not 100% covered by tests, though -- ex. I'm not familiar enough with RxJava to write unit tests for it and there are some sections of code which are difficult to test without some code refactoring (which I did not want to do too much of).

Hopefully, this can give others some guidance on writing some unit tests and we can continue to cover more of Shuttle!

![tests](https://cloud.githubusercontent.com/assets/5898509/23388315/67e5c0f0-fd2f-11e6-9c42-1f55b1b96138.JPG)

## Unit Test Details
Added two unit test classes:
- `ShuttleUtilsTest` - uses Robolectric to test the methods that specifically rely on the Android framework or would be difficult to mock up the reliance on the Android framework.
- `ShuttleUtilsPowerMockTest` - uses PowerMock to test methods where all external reliance can be mocked out. Testing with PowerMock is faster than testing with Robolectric. Once Robolectric 3.3 is released and PowerMock compatibility is fixed, then this testing class can be merged with `ShuttleUtilsTest` (but for now, the separate classes may also help with organization and/or learning).

I also moved one section of code (a `BuildConfig.DEBUG` check) from `ShuttleUtils` to `ShuttleApplication` which allowed me to write a test for `ShuttleUtils#isUpgraded`.

**Note**: these two test classes are in _the same package_ as `ShuttleUtils` (`com.simplecity.amp_library.utils`), but under the `test` directory, so they can access package-private methods in `ShuttleUtils` :) (for example, we can write a test for and call `ShuttleUtils#getSongsForFileObjects` which is not `public`).
- I updated the packages of the two example tests added in https://github.com/timusus/Shuttle/pull/6, for consistency.

## Test Dependencies
Just some extra info.

Some detailed descriptions of the testing libraries and versions chosen, if applicable:
- **[Robolectric](https://github.com/robolectric/robolectric)** - when you run unit tests, they run off of standard Java libraries -- so no Android-specific code is available (ex. `Context`). Put simply, Robolectric allows you to use Android-specific classes in tests and emulates their behavior. There is some startup overhead though, so it is typically slower than running a standard JUnit test.
- **[Mockito](https://github.com/mockito/mockito)** - allows you to create "fake" representations of classes (mocks) and allows you to specify what should be returned by methods called on mock objects. Makes unit testing simpler because you don't have to worry about the implementation of other objects that your class-under-test is using.
- **[PowerMock](https://github.com/powermock/powermock)** - allows for... more powerful mocks -- most useful, however, is the ability to control the returns from static methods (ex. `ShuttleApplication#getInstance` to return a mocked `ShuttleApplication`)
- **[AssertJ](http://joel-costigliola.github.io/assertj/)** - not strictly needed, but I think it provides a nice, readible way to write test assertions.

Important note about versions:
- PowerMock does not fully support Mockito 2 yet: https://github.com/powermock/powermock/wiki/Mockito2_maven
- PowerMock and Robolectric won't work together until Robolectric 3.3 is released: https://github.com/robolectric/robolectric/wiki/Using-PowerMock
