### PR TITLE
Replace QuickLyric link with a Dynamic link

### DIFF
--- a/app/src/main/java/com/simplecity/amp_library/ui/fragments/LyricsFragment.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/fragments/LyricsFragment.java
@@ -152,7 +152,7 @@ public class LyricsFragment extends BaseFragment {
                 mQuickLyricButton.setText(R.string.quicklyric_play_store);
                 mQuickLyricButton.setOnClickListener(v -> {
                     try {
-                        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=com.geecko.QuickLyric"));
+                        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://d3khd.app.goo.gl/jdF1"));
                         startActivity(intent);
                     } catch (ActivityNotFoundException ignored) {
                         // If the user doesn't have the play store on their device


### PR DESCRIPTION
This makes it possible for me to keep track of how many users have installed QuickLyric after clicking this link. The dynamic link (from Firebase) works for everyone, even if they don't have the play store installed. An exception is still possible if the user doesn't have a browser.