### PR TITLE
Add tag for itemBackground for AppTheme.Solid.Light theme

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -159,6 +159,7 @@
         <item name="ic_placeholder_medium">@drawable/ic_placeholder_light_medium</item>
 
         <item name="toolbar_theme">@style/ThemeOverlay.AppCompat.Dark.ActionBar</item>
+        <item name="android:itemBackground">@color/bg_light</item>
         <item name="toolbar_popup_theme">@style/ThemeOverlay.AppCompat.Light</item>
 
         <item name="android:windowContentOverlay">@null</item>


### PR DESCRIPTION
Setting toolbar_theme to the Dark.ActionBar theme caused the background
of the menu's list items to turn dark. Reversed the change by manually
setting the itemBackground tag to @color/bg_light.

Resolves: #96