### PR TITLE
Fix PagerAdapter displayed tab

### DIFF
--- a/app/src/main/java/com/simplecity/amp_library/ui/adapters/PagerAdapter.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/adapters/PagerAdapter.java
@@ -3,6 +3,7 @@ package com.simplecity.amp_library.ui.adapters;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentPagerAdapter;
+import android.support.v4.app.FragmentTransaction;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,8 +22,22 @@ public class PagerAdapter extends FragmentPagerAdapter {
      *
      * @param fragmentManager The {@link FragmentManager} to use
      */
-    public PagerAdapter(FragmentManager fragmentManager) {
+    public PagerAdapter(FragmentManager fragmentManager, boolean refreshPager) {
         super(fragmentManager);
+
+        /*
+		 * Removing all displayed fragments to avoid the problem when changing the displayed tabs
+         */
+        if (refreshPager) {
+            List<Fragment> childFragments = fragmentManager.getFragments();
+            if (childFragments != null && !childFragments.isEmpty()) {
+                FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
+                for (Fragment childFragment : childFragments) {
+                    if (childFragment != null) fragmentTransaction.remove(childFragment);
+                }
+                fragmentTransaction.commitAllowingStateLoss();
+            }
+        }
     }
 
     @Override

--- a/app/src/main/java/com/simplecity/amp_library/ui/fragments/LibraryController.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/fragments/LibraryController.java
@@ -1,26 +1,5 @@
 package com.simplecity.amp_library.ui.fragments;
 
-import android.content.IntentFilter;
-import android.content.SharedPreferences;
-import android.os.Bundle;
-import android.preference.PreferenceManager;
-import android.support.annotation.Nullable;
-import android.support.design.widget.AppBarLayout;
-import android.support.design.widget.TabLayout;
-import android.support.v4.util.Pair;
-import android.support.v4.view.ViewCompat;
-import android.support.v4.view.ViewPager;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
-import android.transition.Transition;
-import android.transition.TransitionInflater;
-import android.view.LayoutInflater;
-import android.view.Menu;
-import android.view.MenuInflater;
-import android.view.MenuItem;
-import android.view.View;
-import android.view.ViewGroup;
-
 import com.afollestad.aesthetic.Aesthetic;
 import com.afollestad.aesthetic.ViewBackgroundAction;
 import com.annimon.stream.Stream;
@@ -48,6 +27,27 @@ import com.simplecity.amp_library.utils.DialogUtils;
 import com.simplecity.amp_library.utils.MusicUtils;
 import com.simplecity.amp_library.utils.SettingsManager;
 import com.simplecity.multisheetview.ui.view.MultiSheetView;
+
+import android.content.IntentFilter;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.support.annotation.Nullable;
+import android.support.design.widget.AppBarLayout;
+import android.support.design.widget.TabLayout;
+import android.support.v4.util.Pair;
+import android.support.v4.view.ViewCompat;
+import android.support.v4.view.ViewPager;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+import android.transition.Transition;
+import android.transition.TransitionInflater;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -97,6 +97,8 @@ public class LibraryController extends BaseFragment implements
 
     private Unbinder unbinder;
 
+    private boolean refreshPager = false;
+
     public static FragmentInfo fragmentInfo() {
         return new FragmentInfo(LibraryController.class, null, "LibraryController");
     }
@@ -122,9 +124,9 @@ public class LibraryController extends BaseFragment implements
 
         ((AppCompatActivity) getActivity()).setSupportActionBar(toolbar);
 
-        setupViewPager();
+        RxBroadcast.fromLocalBroadcast(getContext(), new IntentFilter(EVENT_TABS_CHANGED)).subscribe(onNext -> {refreshPager = true;});
 
-        compositeDisposable.add(RxBroadcast.fromLocalBroadcast(getContext(), new IntentFilter(EVENT_TABS_CHANGED)).subscribe());
+        setupViewPager();
 
         return rootView;
     }
@@ -178,7 +180,8 @@ public class LibraryController extends BaseFragment implements
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(getContext());
         CategoryItem.getCategoryItems(sharedPreferences);
 
-        PagerAdapter adapter = new PagerAdapter(getChildFragmentManager());
+        PagerAdapter adapter = new PagerAdapter(getChildFragmentManager(), refreshPager);
+        refreshPager = false;
 
         List<CategoryItem> categoryItems = Stream.of(CategoryItem.getCategoryItems(sharedPreferences))
                 .filter(categoryItem -> categoryItem.isEnabled)


### PR DESCRIPTION
When we change the displayed tab and go back to the tab list, the adapter change tab name but not change tab fragment, it keep the old fragment.