### PR TITLE
Storage Access Framework write permissions

### DIFF
--- a/app/src/main/java/com/simplecity/amp_library/tagger/TaggerDialog.java
+++ b/app/src/main/java/com/simplecity/amp_library/tagger/TaggerDialog.java
@@ -419,7 +419,7 @@ public class TaggerDialog extends DialogFragment {
                     if (ShuttleUtils.hasLollipop()) {
                         Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
                         if (intent.resolveActivity(ShuttleApplication.getInstance().getPackageManager()) != null) {
-                            getActivity().startActivityForResult(intent, DOCUMENT_TREE_REQUEST_CODE);
+                            this.startActivityForResult(intent, DOCUMENT_TREE_REQUEST_CODE);
                         } else {
                             Toast.makeText(getContext(), R.string.R_string_toast_no_document_provider, Toast.LENGTH_LONG).show();
                         }

--- a/app/src/main/java/com/simplecity/amp_library/tagger/TaggerUtils.java
+++ b/app/src/main/java/com/simplecity/amp_library/tagger/TaggerUtils.java
@@ -2,6 +2,7 @@ package com.simplecity.amp_library.tagger;
 
 import android.annotation.TargetApi;
 import android.content.Context;
+import android.content.UriPermission;
 import android.net.Uri;
 import android.os.Build;
 import android.support.v4.provider.DocumentFile;
@@ -30,6 +31,16 @@ public class TaggerUtils {
     private TaggerUtils() {
 
     }
+	
+	@TargetApi(Build.VERSION_CODES.LOLLIPOP)
+	public static String getDocumentTree() {
+		String treeUri = SettingsManager.getInstance().getDocumentTreeUri();
+		List<UriPermission> perms = ShuttleApplication.getInstance().getContentResolver().getPersistedUriPermissions();
+		for (UriPermission perm : perms) {
+			if (perm.getUri().toString().equals(treeUri) && perm.isWritePermission()) return treeUri;
+		}
+		return null;
+	}
 
     /**
      * Checks the passed in paths to see whether the file at the given path is available in our
@@ -44,7 +55,7 @@ public class TaggerUtils {
 
         boolean hasDocumentTreePermission = false;
 
-        String treeUri = SettingsManager.getInstance().getDocumentTreeUri();
+        String treeUri = getDocumentTree();
         if (treeUri == null) {
             //We don't have any document tree at all - so we're not going to have permission for any files.
             return false;


### PR DESCRIPTION
This fixes tag editing for files on external SD card.

As it turns out, tag editing was already implemented, but permission request result was completely discarded. Tree Uri picker was called from Activity context, but onActivityResult was handled in dialog.

File deletion still needs to be implemented.