### PR TITLE
Fixed play next duplication issue

### DIFF
--- a/app/src/main/java/com/simplecity/amp_library/playback/MusicService.java
+++ b/app/src/main/java/com/simplecity/amp_library/playback/MusicService.java
@@ -1031,7 +1031,9 @@ public class MusicService extends Service {
         editor.apply();
     }
 
-    /** Converts a playlist to a String which can be saved to SharedPrefs */
+    /**
+     * Converts a playlist to a String which can be saved to SharedPrefs
+     */
     private String serializePlaylist(List<Song> list) {
 
         // The current playlist is saved as a list of "reverse hexadecimal"
@@ -1061,7 +1063,9 @@ public class MusicService extends Service {
         return q.toString();
     }
 
-    /** Converts a string representation of a playlist from SharedPrefs into a list of songs. */
+    /**
+     * Converts a string representation of a playlist from SharedPrefs into a list of songs.
+     */
     private List<Song> deserializePlaylist(String listString, List<Song> allSongs) {
         List<Long> ids = new ArrayList<>();
         int n = 0;
@@ -1481,9 +1485,9 @@ public class MusicService extends Service {
     /**
      * Opens a list for playback
      *
-     * @param songs         The list of tracks to open
-     * @param shuffleMode   The shuffle mode
-     * @param position      The position to start playback at
+     * @param songs       The list of tracks to open
+     * @param shuffleMode The shuffle mode
+     * @param position    The position to start playback at
      */
     public void open(List<Song> songs, final int position, final int shuffleMode) {
         synchronized (this) {
@@ -1657,7 +1661,9 @@ public class MusicService extends Service {
         return albumSongsInOrder;
     }
 
-    /** Shuffles a list of songs, grouping by album and arranging songs in that album in order. */
+    /**
+     * Shuffles a list of songs, grouping by album and arranging songs in that album in order.
+     */
     private List<Song> albumShuffleSongs(List<Song> songs, boolean isAddingToQueue) {
 
         if (songs == null || songs.isEmpty()) {
@@ -1697,7 +1703,7 @@ public class MusicService extends Service {
 
         for (Album album : trackShuffleListAlbums) {
             List<Song> albumSongsInQueue =
-                   new ArrayList<>(trackShuffleListAlbumMap.get(album));
+                    new ArrayList<>(trackShuffleListAlbumMap.get(album));
             List<Song> intersection = albumQueueIntersect(album, albumSongsInQueue);
             newShuffleList.addAll(intersection);
         }

--- a/app/src/main/java/com/simplecity/amp_library/search/SearchPresenter.java
+++ b/app/src/main/java/com/simplecity/amp_library/search/SearchPresenter.java
@@ -477,7 +477,7 @@ public class SearchPresenter extends Presenter<SearchView> implements
                         if (searchView != null) {
                             searchView.showTaggerDialog(taggerDialog);
                         }
-                    }, null));
+                    }, null, null));
             menu.show();
         }
 

--- a/app/src/main/java/com/simplecity/amp_library/search/VoiceSearchActivity.java
+++ b/app/src/main/java/com/simplecity/amp_library/search/VoiceSearchActivity.java
@@ -10,7 +10,6 @@ import android.widget.Toast;
 import com.annimon.stream.Stream;
 import com.simplecity.amp_library.model.Album;
 import com.simplecity.amp_library.model.AlbumArtist;
-import com.simplecity.amp_library.playback.MusicService;
 import com.simplecity.amp_library.ui.activities.BaseActivity;
 import com.simplecity.amp_library.ui.activities.MainActivity;
 import com.simplecity.amp_library.utils.ComparisonUtils;

--- a/app/src/main/java/com/simplecity/amp_library/ui/detail/BaseDetailFragment.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/detail/BaseDetailFragment.java
@@ -771,7 +771,7 @@ public abstract class BaseDetailFragment extends BaseFragment implements
         MenuUtils.setupSongMenu(popupMenu, showSongOverflowRemoveButton());
         popupMenu.setOnMenuItemClickListener(MenuUtils.getSongMenuClickListener(getContext(), song,
                 taggerDialog -> taggerDialog.show(getFragmentManager()),
-                () -> songRemoved(position, song)));
+                () -> songRemoved(position, song), null));
         popupMenu.show();
     }
 

--- a/app/src/main/java/com/simplecity/amp_library/ui/fragments/QueueFragment.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/fragments/QueueFragment.java
@@ -299,6 +299,11 @@ public class QueueFragment extends BaseFragment implements
         adapter.removeItem(position);
     }
 
+    @Override
+    public void moveQueueItem(int from, int to) {
+        adapter.moveItem(from, to);
+    }
+
     private PlayerViewAdapter playerViewAdapter = new PlayerViewAdapter() {
         @Override
         public void trackInfoChanged(@Nullable Song song) {

--- a/app/src/main/java/com/simplecity/amp_library/ui/fragments/SongFragment.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/fragments/SongFragment.java
@@ -287,7 +287,7 @@ public class SongFragment extends BaseFragment implements
         MenuUtils.setupSongMenu(menu, false);
         menu.setOnMenuItemClickListener(MenuUtils.getSongMenuClickListener(getContext(), song,
                 taggerDialog -> taggerDialog.show(getFragmentManager()),
-                null));
+                null, null));
         menu.show();
     }
 

--- a/app/src/main/java/com/simplecity/amp_library/ui/fragments/SuggestedFragment.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/fragments/SuggestedFragment.java
@@ -82,7 +82,7 @@ public class SuggestedFragment extends BaseFragment implements
         public void onSongOverflowClicked(View v, Song song) {
             PopupMenu popupMenu = new PopupMenu(getContext(), v);
             MenuUtils.setupSongMenu(popupMenu, false);
-            popupMenu.setOnMenuItemClickListener(MenuUtils.getSongMenuClickListener(getContext(), song, taggerDialog -> taggerDialog.show(getFragmentManager()), null));
+            popupMenu.setOnMenuItemClickListener(MenuUtils.getSongMenuClickListener(getContext(), song, taggerDialog -> taggerDialog.show(getFragmentManager()), null, null));
             popupMenu.show();
         }
     }

--- a/app/src/main/java/com/simplecity/amp_library/ui/presenters/QueuePresenter.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/presenters/QueuePresenter.java
@@ -110,11 +110,21 @@ public class QueuePresenter extends Presenter<QueueView> {
         MusicUtils.removeFromQueue(song, true);
     }
 
+    private void playNext(int position){
+        int newPosition = MusicUtils.getQueuePosition() + 1;
+
+        QueueView queueView = getView();
+        if (queueView != null) {
+            queueView.moveQueueItem(position, newPosition);
+        }
+
+        MusicUtils.moveQueueItem(position, newPosition);
+    }
+
     private void loadData() {
         QueueView queueView = getView();
         data = Stream.of(MusicUtils.getQueue())
                 .map(song -> {
-
                     // Look for an existing SongView wrapping the song, we'll reuse it if it exists.
                     SongView songView = (SongView) Stream.of(data)
                             .filter(viewModel -> viewModel instanceof SongView && (((SongView) viewModel).song.equals(song)))
@@ -164,7 +174,8 @@ public class QueuePresenter extends Presenter<QueueView> {
                             queueView.showTaggerDialog(taggerDialog);
                         }
                     },
-                    () -> removeFromQueue(position, song)));
+                    () -> removeFromQueue(position, song),
+                    () -> playNext(position)));
             menu.show();
         }
 

--- a/app/src/main/java/com/simplecity/amp_library/ui/views/QueueView.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/views/QueueView.java
@@ -21,4 +21,6 @@ public interface QueueView {
     void showTaggerDialog(TaggerDialog taggerDialog);
 
     void removeFromQueue(int position);
+
+    void moveQueueItem(int from, int to);
 }

--- a/app/src/main/java/com/simplecity/amp_library/utils/MenuUtils.java
+++ b/app/src/main/java/com/simplecity/amp_library/utils/MenuUtils.java
@@ -101,7 +101,7 @@ public class MenuUtils implements MusicUtils.Defs {
                 .build()
                 .show();
     }
-    
+
     public static void setupSongMenu(PopupMenu menu, boolean showRemoveButton) {
         menu.inflate(R.menu.menu_song);
 
@@ -138,11 +138,15 @@ public class MenuUtils implements MusicUtils.Defs {
         };
     }
 
-    public static PopupMenu.OnMenuItemClickListener getSongMenuClickListener(Context context, Song song, UnsafeConsumer<TaggerDialog> tagEditorCallback, @Nullable UnsafeAction songRemoved) {
+    public static PopupMenu.OnMenuItemClickListener getSongMenuClickListener(Context context, Song song, UnsafeConsumer<TaggerDialog> tagEditorCallback, @Nullable UnsafeAction onSongRemoved, @Nullable UnsafeAction onPlayNext) {
         return item -> {
             switch (item.getItemId()) {
                 case R.id.playNext:
-                    playNext(context, song);
+                    if (onPlayNext != null) {
+                        onPlayNext.run();
+                    } else {
+                        playNext(context, song);
+                    }
                     return true;
                 case NEW_PLAYLIST:
                     newPlaylist(context, Collections.singletonList(song));
@@ -172,8 +176,8 @@ public class MenuUtils implements MusicUtils.Defs {
                     delete(context, Collections.singletonList(song));
                     return true;
                 case R.id.remove:
-                    if (songRemoved != null) {
-                        songRemoved.run();
+                    if (onSongRemoved != null) {
+                        onSongRemoved.run();
                     }
                     return true;
             }


### PR DESCRIPTION
When ‘play next’ is chosen from the queue, move the song to the next position, rather than inserting a duplicate.