### PR TITLE
Fix nextPlayPos in clearQueue()

### DIFF
--- a/app/src/main/java/com/simplecity/amp_library/playback/MusicService.java
+++ b/app/src/main/java/com/simplecity/amp_library/playback/MusicService.java
@@ -2288,6 +2288,7 @@ public class MusicService extends Service {
         setShuffleMode(ShuffleMode.OFF);
         stop(true);
         playPos = -1;
+        nextPlayPos = -1;
         notifyChange(InternalIntents.QUEUE_CHANGED);
     }
 


### PR DESCRIPTION
The problem was that MediaPlayerHandler.java got a message _TRACK_WENT_TO_NEXT_ because of `stop()` in `clearQueue()` which is in `MusicService.java` . This changed the playPos to nextPlayPos but nextPlayPos was not changed adequately(`clearQueue()` does not mean that the it should go to next track). This PR fixes that.