### PR TITLE
Add commit subject to Slack integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,3 +65,5 @@ deploy:
 # Slack build notifications
 notifications:
   slack: shuttlemusicplayer:g90QK9lL6Hg5jfzegqjjNqqN
+  template: 
+    - "Build <%{build_url}|#%{build_number}> (<%{compare_url}|%{commit}: '%{commit_subject}'>) by %{author} %{result} in %{duration}."


### PR DESCRIPTION
Updates the Travis Slack template to include the commit subject.