### PR TITLE
Prevent user to display Folder tab if he doesn't have Shuttle+

### DIFF
--- a/app/src/main/java/com/simplecity/amp_library/ui/modelviews/TabViewModel.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/modelviews/TabViewModel.java
@@ -46,12 +46,12 @@ public class TabViewModel extends BaseViewModel<TabViewModel.ViewHolder> {
     }
 
     void onCheckboxClicked(ViewHolder viewHolder, boolean checked) {
+        categoryItem.isChecked = checked;
         if (categoryItem.type == CategoryItem.Type.FOLDERS) {
             if (listener != null) {
                 listener.onFolderChecked(this, viewHolder);
             }
         }
-        categoryItem.isChecked = checked;
     }
 
     void onStartDrag(ViewHolder viewHolder) {


### PR DESCRIPTION
This little bug make possible to display Folder tab, even if the user doesn't have Shuttle+.
To reproduce the bug, go to Settings, Display, and Choose Tab Items. If you doesn't have Shuttle+, check Folder item, then press "No, thanks" and Done.