### PR TITLE
Share option fix for songs on external devices

### DIFF
--- a/app/src/main/res/xml/provider_paths.xml
+++ b/app/src/main/res/xml/provider_paths.xml
@@ -11,5 +11,8 @@
     <external-files-path
         name="external_files_path"
         path="."/>
-
+    
+    <root-path
+        name="external_path"
+        path="/storage/"/>
 </paths>


### PR DESCRIPTION
As you might have noticed, it wasn't possible to share songs from any external storage, because the share dialog wasn't showing. This was because of the error "Failed to find configured root" with FileProvider in SongExt.tk .
Adding few lines to provider_paths.xml seems to solve the problem.
Tested with Android 7.0 and a SD Card, looks like it works fine.