### PR TITLE
Add Visualizer feature

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,8 @@
     <uses-permission android:name="android.permission.WRITE_SETTINGS"/>
     <!-- Used to read mediastore db, caching artwork etc. -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <!-- Used by the visualizer -->
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <!-- ## End 'Special' permissions ##-->
 
     <application

--- a/app/src/main/java/com/simplecity/amp_library/ui/fragments/PlayerFragment.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/fragments/PlayerFragment.java
@@ -780,8 +780,10 @@ public class PlayerFragment extends BaseFragment implements
             fftView.plotData(new int[64]);
         }
     }
+
     @Override
     public void onWaveFormDataCapture(Visualizer visualizer, byte[] bytes, int samplingRate) {};
+
     @Override
     public void onFftDataCapture(Visualizer visualizer, byte[] bytes, int samplingRate) {
         if (fftView == null) return;

--- a/app/src/main/java/com/simplecity/amp_library/ui/fragments/PlayerFragment.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/fragments/PlayerFragment.java
@@ -767,7 +767,7 @@ public class PlayerFragment extends BaseFragment implements
                     mVisualizer = new Visualizer(mediaManager.getAudioSessionId());
                     mVisualizer.setEnabled(false);
                     mVisualizer.setCaptureSize(mVisualizer.getCaptureSizeRange()[1]);
-                    mVisualizer.setDataCaptureListener(this, 20000, false, true);
+                    mVisualizer.setDataCaptureListener(this, ((mVisualizer.getMaxCaptureRate() > 20000) ? 20000 : mVisualizer.getMaxCaptureRate()), false, true);
                     mVisualizer.setEnabled(mediaManager.isPlaying());
                 } else if (mVisualizer != null) {
                     mVisualizer.setEnabled(mediaManager.isPlaying());

--- a/app/src/main/java/com/simplecity/amp_library/ui/fragments/PlayerFragment.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/fragments/PlayerFragment.java
@@ -5,6 +5,7 @@ import android.animation.AnimatorListenerAdapter;
 import android.animation.ValueAnimator;
 import android.annotation.SuppressLint;
 import android.graphics.drawable.Drawable;
+import android.media.audiofx.Visualizer;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
@@ -50,12 +51,14 @@ import com.simplecity.amp_library.glide.palette.ColorSetTranscoder;
 import com.simplecity.amp_library.model.AlbumArtist;
 import com.simplecity.amp_library.model.Genre;
 import com.simplecity.amp_library.model.Song;
+import com.simplecity.amp_library.playback.MediaManager;
 import com.simplecity.amp_library.playback.QueueManager;
 import com.simplecity.amp_library.rx.UnsafeAction;
 import com.simplecity.amp_library.rx.UnsafeConsumer;
 import com.simplecity.amp_library.tagger.TaggerDialog;
 import com.simplecity.amp_library.ui.drawer.NavigationEventRelay;
 import com.simplecity.amp_library.ui.presenters.PlayerPresenter;
+import com.simplecity.amp_library.ui.views.FFTView;
 import com.simplecity.amp_library.ui.views.FavoriteActionBarView;
 import com.simplecity.amp_library.ui.views.PlayPauseView;
 import com.simplecity.amp_library.ui.views.PlayerView;
@@ -84,7 +87,8 @@ import javax.inject.Inject;
 
 public class PlayerFragment extends BaseFragment implements
         PlayerView,
-        Toolbar.OnMenuItemClickListener {
+        Toolbar.OnMenuItemClickListener,
+        Visualizer.OnDataCaptureListener {
 
     private final String TAG = ((Object) this).getClass().getSimpleName();
 
@@ -136,6 +140,9 @@ public class PlayerFragment extends BaseFragment implements
     @BindView(R.id.backgroundView)
     ImageView backgroundView;
 
+    @BindView(R.id.fftView)
+    FFTView fftView;
+                
     @Nullable
     @BindView(R.id.seekbar)
     SizableSeekBar seekBar;
@@ -164,6 +171,10 @@ public class PlayerFragment extends BaseFragment implements
     private boolean isLandscape;
 
     private boolean isExpanded;
+
+    @Inject
+    MediaManager mediaManager;
+    private Visualizer mVisualizer;
 
     @Nullable
     private ValueAnimator colorAnimator;
@@ -333,12 +344,14 @@ public class PlayerFragment extends BaseFragment implements
                     }
                 }, throwable -> Log.e(TAG, "error listening for sheet slide events", throwable)));
 
+        startVisualizer();
         update();
     }
 
     @Override
     public void onPause() {
         disposables.clear();
+        if (mVisualizer != null) mVisualizer.setEnabled(false);
         super.onPause();
     }
 
@@ -401,6 +414,8 @@ public class PlayerFragment extends BaseFragment implements
         if (!isPlaying) {
             snowfallView.removeSnow();
         }
+            
+        startVisualizer();
     }
 
     @Override
@@ -547,6 +562,10 @@ public class PlayerFragment extends BaseFragment implements
 
         if (playPauseView != null) {
             playPauseView.setDrawableColor(colorSet.getPrimaryTextColor());
+        }
+
+        if (fftView != null) {
+            fftView.setColor(colorSet.getAccentColor());
         }
 
         this.colorSet = colorSet;
@@ -739,5 +758,41 @@ public class PlayerFragment extends BaseFragment implements
                 Aesthetic.get(getContext()).colorAccent(),
                 Pair::new
         ).map(pair -> ColorSet.Companion.fromPrimaryAccentColors(getContext(), pair.first, pair.second));
+    }
+
+    private void startVisualizer() {
+        if (SettingsManager.getInstance().getVisualizerEnabled()) {
+            try {
+                if (mVisualizer == null && mediaManager.getAudioSessionId() != 0) {
+                    mVisualizer = new Visualizer(mediaManager.getAudioSessionId());
+                    mVisualizer.setEnabled(false);
+                    mVisualizer.setCaptureSize(mVisualizer.getCaptureSizeRange()[1]);
+                    mVisualizer.setDataCaptureListener(this, 20000, false, true);
+                    mVisualizer.setEnabled(mediaManager.isPlaying());
+                } else if (mVisualizer != null) {
+                    mVisualizer.setEnabled(mediaManager.isPlaying());
+                }
+            } catch (RuntimeException e) {
+                SettingsManager.getInstance().setVisualizerEnabled(false);
+            }
+        } else if (mVisualizer != null) {
+            mVisualizer.setEnabled(false);
+            fftView.plotData(new int[64]);
+        }
+            
+        if (!SettingsManager.getInstance().getEqualizerEnabled()) {
+            mediaManager.openEqualizerSession(false, mediaManager.getAudioSessionId());
+        } else {
+            mediaManager.closeEqualizerSessions(false, mediaManager.getAudioSessionId());
+        }
+    }
+    @Override
+    public void onWaveFormDataCapture(Visualizer visualizer, byte[] bytes, int samplingRate) {};
+    @Override
+    public void onFftDataCapture(Visualizer visualizer, byte[] bytes, int samplingRate) {
+        if (fftView == null) return;
+        int[] data = new int[64];
+        for (int i = 0; i < 64; i++) data[i] = (int) (2 * Math.sqrt(bytes[2*i] * bytes[2*i] + bytes[2*i+1] * bytes[2*i+1]));
+        fftView.plotData(data);
     }
 }

--- a/app/src/main/java/com/simplecity/amp_library/ui/fragments/PlayerFragment.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/fragments/PlayerFragment.java
@@ -779,12 +779,6 @@ public class PlayerFragment extends BaseFragment implements
             mVisualizer.setEnabled(false);
             fftView.plotData(new int[64]);
         }
-            
-        if (!SettingsManager.getInstance().getEqualizerEnabled()) {
-            mediaManager.openEqualizerSession(false, mediaManager.getAudioSessionId());
-        } else {
-            mediaManager.closeEqualizerSessions(false, mediaManager.getAudioSessionId());
-        }
     }
     @Override
     public void onWaveFormDataCapture(Visualizer visualizer, byte[] bytes, int samplingRate) {};

--- a/app/src/main/java/com/simplecity/amp_library/ui/settings/SettingsParentFragment.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/settings/SettingsParentFragment.java
@@ -342,6 +342,15 @@ public class SettingsParentFragment extends BaseNavigationController implements
                     return true;
                 });
             }
+            
+            // Playback
+            SwitchPreferenceCompat enableVisualizerPreference = (SwitchPreferenceCompat) findPreference(SettingsManager.KEY_PREF_VISUALIZER);
+            if (enableVisualizerPreference != null) {
+                enableVisualizerPreference.setOnPreferenceChangeListener((preference, newValue) -> {
+                    settingsPresenter.changeVisualizerPreferenceClicked(getContext());
+                    return true;
+                });
+            }
 
             // Headset/Bluetooth
 
@@ -564,6 +573,12 @@ public class SettingsParentFragment extends BaseNavigationController implements
 
         @Override
         public void showArtworkPreferenceChangeDialog(MaterialDialog dialog) {
+            dialog.show();
+        }
+        
+        // Playback
+        @Override
+        public void showVisualizerPreferenceChangeDialog(MaterialDialog dialog) {
             dialog.show();
         }
 

--- a/app/src/main/java/com/simplecity/amp_library/ui/settings/SettingsView.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/settings/SettingsView.java
@@ -36,6 +36,9 @@ public interface SettingsView extends PurchaseView {
 
     void showArtworkPreferenceChangeDialog(MaterialDialog dialog);
 
+    //Playback
+    void showVisualizerPreferenceChangeDialog(MaterialDialog dialog);
+    
     // Scrobbling
     void launchDownloadScrobblerIntent(Intent intent);
 

--- a/app/src/main/java/com/simplecity/amp_library/ui/views/FFTView.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/views/FFTView.java
@@ -1,0 +1,79 @@
+package com.simplecity.amp_library.ui.views;
+
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.Rect;
+import android.support.v7.widget.AppCompatImageView;
+import android.util.AttributeSet;
+
+public class FFTView extends AppCompatImageView {
+
+    private Rect[] rectangle;
+
+    private int rectWidth;
+    private int paddingLeft;
+    private int drawingColor;
+
+    public FFTView(Context context) {
+        super(context);
+        initialize();
+    }
+
+    public FFTView(Context context, AttributeSet attrst) {
+        super(context, attrst);
+        initialize();
+    }
+
+    public FFTView(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+        initialize();
+    }
+
+    private void initialize() {
+        rectangle = new Rect[128];
+
+        drawingColor = Color.WHITE;
+
+        for(int i=0; i<128; i++) {
+            rectangle[i] = new Rect();
+        }
+
+        rectWidth = (int) this.getWidth() / 64;
+        paddingLeft = (this.getWidth() - rectWidth*64) / 2;
+    }
+
+    public void setColor(int newColor) {
+        drawingColor = newColor;
+    }
+
+    @Override
+    protected void onSizeChanged(int xNew, int yNew, int xOld, int yOld){
+        super.onSizeChanged(xNew, yNew, xOld, yOld);
+
+        rectWidth = this.getWidth() / 64;
+        paddingLeft = (this.getWidth() - rectWidth*64) / 2;
+    }
+
+    @Override
+    protected void onDraw(Canvas canvas) {
+        super.onDraw(canvas);
+
+        canvas.drawColor(Color.TRANSPARENT);
+        Paint paint = new Paint();
+        paint.setColor(drawingColor);
+        for(int i=0; i<64; i++) {
+            canvas.drawRect(rectangle[i], paint);
+        }
+        this.postInvalidate();
+    }
+
+    public void plotData(int[] data) {
+        for(int i=0; i<data.length; i++) {
+            // create a rectangle that we'll draw later
+            rectangle[i] = new Rect(rectWidth*i + paddingLeft, this.getHeight() - data[i], rectWidth*(i+1) + paddingLeft, this.getHeight());
+        }
+        invalidate();
+    }
+}

--- a/app/src/main/java/com/simplecity/amp_library/utils/SettingsManager.java
+++ b/app/src/main/java/com/simplecity/amp_library/utils/SettingsManager.java
@@ -54,6 +54,7 @@ public class SettingsManager extends BaseSettingsManager {
 
     // Playback
     public static String KEY_PREF_REMEMBER_SHUFFLE = "pref_remember_shuffle";
+    public static String KEY_PREF_VISUALIZER = "pref_enable_visualizer";
 
     // Upgrade
     public static String KEY_PREF_UPGRADE = "pref_upgrade";
@@ -433,6 +434,13 @@ public class SettingsManager extends BaseSettingsManager {
 
     public void setRememberShuffle(boolean rememberShuffle) {
         setBool(KEY_PREF_REMEMBER_SHUFFLE, rememberShuffle);
+    }
+    
+    public boolean getVisualizerEnabled() {
+        return getBool(KEY_PREF_VISUALIZER, false);
+    }
+    public void setVisualizerEnabled(boolean visualizerEnabled) {
+        setBool(KEY_PREF_VISUALIZER, visualizerEnabled);
     }
 
     // Library Controller

--- a/app/src/main/res/layout/fragment_player.xml
+++ b/app/src/main/res/layout/fragment_player.xml
@@ -17,6 +17,15 @@
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         tools:background="#B0363A"/>
+    
+    <com.simplecity.amp_library.ui.views.FFTView
+        android:id="@+id/fftView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintDimensionRatio="w,1:1"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <ImageView
         android:id="@+id/backgroundView"

--- a/app/src/main/res/xml/settings_playback.xml
+++ b/app/src/main/res/xml/settings_playback.xml
@@ -11,6 +11,12 @@
             android:key="pref_remember_shuffle"
             android:summary="@string/pref_summary_remember_shuffle"
             android:title="@string/pref_title_remember_shuffle"/>
+        
+        <android.support.v7.preference.SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="pref_enable_visualizer"
+            android:summary="Enable or disable Visualizer on the 'Now Playing' screen"
+            android:title="Enable/Disable Visualizer"/>
 
     </android.support.v7.preference.PreferenceCategory>
 


### PR DESCRIPTION
This feature adds a "visualizer" on the 'now playing' screen.
It uses the Visualizer class which provide the Fast Fourier Transform of an audio session. I adapted the data into a view wich displays them as bars.
I also added a setting option to enable/disable this, but I didn't added strings into strings.xml files, because I don't know if I may do it myself.
The feature seems to work well on my device, as well as on the device of a friend of mine.
I'm working on enhancing the display, but I think the whole code might be improved.