### PR TITLE
Add "Go to" menu item to artists, albums, and songs

### DIFF
--- a/app/src/main/java/com/simplecity/amp_library/search/SearchFragment.java
+++ b/app/src/main/java/com/simplecity/amp_library/search/SearchFragment.java
@@ -447,7 +447,7 @@ public class SearchFragment extends BaseFragment implements
         @Override
         public void onSongOverflowClick(int position, View v, Song song) {
             PopupMenu menu = new PopupMenu(v.getContext(), v);
-            SongMenuUtils.INSTANCE.setupSongMenu(menu, false);
+            SongMenuUtils.INSTANCE.setupSongMenu(menu, false, true, true);
             menu.setOnMenuItemClickListener(SongMenuUtils.INSTANCE.getSongMenuClickListener(song, songMenuCallbacksAdapter));
             menu.show();
         }
@@ -474,7 +474,7 @@ public class SearchFragment extends BaseFragment implements
         @Override
         public void onAlbumOverflowClicked(View v, Album album) {
             PopupMenu menu = new PopupMenu(v.getContext(), v);
-            AlbumMenuUtils.INSTANCE.setupAlbumMenu(menu);
+            AlbumMenuUtils.INSTANCE.setupAlbumMenu(menu, true);
             menu.setOnMenuItemClickListener(AlbumMenuUtils.INSTANCE.getAlbumMenuClickListener(v.getContext(), mediaManager, album, albumMenuCallbacksAdapter));
             menu.show();
         }

--- a/app/src/main/java/com/simplecity/amp_library/ui/detail/album/AlbumDetailFragment.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/detail/album/AlbumDetailFragment.java
@@ -559,7 +559,7 @@ public class AlbumDetailFragment extends BaseFragment implements
         @Override
         public void onSongOverflowClick(int position, View v, Song song) {
             PopupMenu popupMenu = new PopupMenu(v.getContext(), v);
-            SongMenuUtils.INSTANCE.setupSongMenu(popupMenu, false);
+            SongMenuUtils.INSTANCE.setupSongMenu(popupMenu, false, false, true);
             popupMenu.setOnMenuItemClickListener(SongMenuUtils.INSTANCE.getSongMenuClickListener(song, songMenuCallbacksAdapter));
             popupMenu.show();
         }

--- a/app/src/main/java/com/simplecity/amp_library/ui/detail/artist/ArtistDetailFragment.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/detail/artist/ArtistDetailFragment.java
@@ -540,7 +540,7 @@ public class ArtistDetailFragment extends BaseFragment implements
         @Override
         public void onSongOverflowClick(int position, View v, Song song) {
             PopupMenu popupMenu = new PopupMenu(v.getContext(), v);
-            SongMenuUtils.INSTANCE.setupSongMenu(popupMenu, false);
+            SongMenuUtils.INSTANCE.setupSongMenu(popupMenu, false, true, false);
             popupMenu.setOnMenuItemClickListener(SongMenuUtils.INSTANCE.getSongMenuClickListener(song, songMenuCallbacksAdapter));
             popupMenu.show();
         }
@@ -568,7 +568,7 @@ public class ArtistDetailFragment extends BaseFragment implements
         @Override
         public void onAlbumOverflowClicked(View v, Album album) {
             PopupMenu popupMenu = new PopupMenu(v.getContext(), v);
-            AlbumMenuUtils.INSTANCE.setupAlbumMenu(popupMenu);
+            AlbumMenuUtils.INSTANCE.setupAlbumMenu(popupMenu, false);
             popupMenu.setOnMenuItemClickListener(AlbumMenuUtils.INSTANCE.getAlbumMenuClickListener(v.getContext(), mediaManager, album, menuFragmentHelper));
             popupMenu.show();
         }

--- a/app/src/main/java/com/simplecity/amp_library/ui/detail/genre/GenreDetailFragment.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/detail/genre/GenreDetailFragment.java
@@ -605,7 +605,7 @@ public class GenreDetailFragment extends BaseFragment implements
         @Override
         public void onSongOverflowClick(int position, View v, Song song) {
             PopupMenu popupMenu = new PopupMenu(v.getContext(), v);
-            SongMenuUtils.INSTANCE.setupSongMenu(popupMenu, false);
+            SongMenuUtils.INSTANCE.setupSongMenu(popupMenu, false, true, true);
             popupMenu.setOnMenuItemClickListener(SongMenuUtils.INSTANCE.getSongMenuClickListener(song, songMenuCallbacksAdapter));
             popupMenu.show();
         }
@@ -633,7 +633,7 @@ public class GenreDetailFragment extends BaseFragment implements
         @Override
         public void onAlbumOverflowClicked(View v, Album album) {
             PopupMenu popupMenu = new PopupMenu(v.getContext(), v);
-            AlbumMenuUtils.INSTANCE.setupAlbumMenu(popupMenu);
+            AlbumMenuUtils.INSTANCE.setupAlbumMenu(popupMenu, true);
             popupMenu.setOnMenuItemClickListener(AlbumMenuUtils.INSTANCE.getAlbumMenuClickListener(v.getContext(), mediaManager, album, albumMenuCallbacksAdapter));
             popupMenu.show();
         }

--- a/app/src/main/java/com/simplecity/amp_library/ui/detail/playlist/PlaylistDetailFragment.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/detail/playlist/PlaylistDetailFragment.java
@@ -621,7 +621,7 @@ public class PlaylistDetailFragment extends BaseFragment implements
         @Override
         public void onSongOverflowClick(int position, View v, Song song) {
             PopupMenu popupMenu = new PopupMenu(v.getContext(), v);
-            SongMenuUtils.INSTANCE.setupSongMenu(popupMenu, playlist.canEdit);
+            SongMenuUtils.INSTANCE.setupSongMenu(popupMenu, playlist.canEdit, true, true);
             popupMenu.setOnMenuItemClickListener(SongMenuUtils.INSTANCE.getSongMenuClickListener(song, songMenuCallbacksAdapter));
             popupMenu.show();
         }

--- a/app/src/main/java/com/simplecity/amp_library/ui/fragments/BaseFragment.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/fragments/BaseFragment.java
@@ -19,6 +19,7 @@ import com.simplecity.amp_library.dagger.module.ActivityModule;
 import com.simplecity.amp_library.dagger.module.FragmentModule;
 import com.simplecity.amp_library.playback.MediaManager;
 import com.simplecity.amp_library.ui.activities.BaseCastActivity;
+import com.simplecity.amp_library.ui.drawer.NavigationEventRelay;
 import com.simplecity.amp_library.ui.views.CustomMediaRouteActionProvider;
 import com.simplecity.amp_library.ui.views.multisheet.MultiSheetEventRelay;
 import com.simplecity.amp_library.utils.AnalyticsManager;
@@ -39,6 +40,9 @@ public abstract class BaseFragment extends BaseController {
 
     @Inject
     protected MediaManager mediaManager;
+
+    @Inject
+    protected NavigationEventRelay navigationEventRelay;
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -132,6 +136,10 @@ public abstract class BaseFragment extends BaseController {
 
     public MediaManager getMediaManager() {
         return mediaManager;
+    }
+
+    public NavigationEventRelay getNavigationEventRelay() {
+        return navigationEventRelay;
     }
 
     protected abstract String screenName();

--- a/app/src/main/java/com/simplecity/amp_library/ui/fragments/PlayerFragment.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/fragments/PlayerFragment.java
@@ -72,6 +72,8 @@ import com.simplecity.amp_library.utils.SettingsManager;
 import com.simplecity.amp_library.utils.ShuttleUtils;
 import com.simplecity.amp_library.utils.StringUtils;
 import com.simplecity.amp_library.utils.color.ArgbEvaluator;
+import com.simplecity.amp_library.utils.menu.MenuUtils;
+
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.Flowable;
 import io.reactivex.Observable;
@@ -600,13 +602,13 @@ public class PlayerFragment extends BaseFragment implements
                 presenter.showLyrics(getContext());
                 return true;
             case R.id.goToArtist:
-                goToArtist();
+                MenuUtils.goToArtist(mediaManager.getAlbumArtist(), navigationEventRelay);
                 return true;
             case R.id.goToAlbum:
-                goToAlbum();
+                MenuUtils.goToAlbum(mediaManager.getAlbum(), navigationEventRelay);
                 return true;
             case R.id.goToGenre:
-                goToGenre();
+                MenuUtils.goToGenre(mediaManager.getGenre(), navigationEventRelay);
                 return true;
             case R.id.editTags:
                 presenter.editTagsClicked(getActivity());
@@ -619,38 +621,6 @@ public class PlayerFragment extends BaseFragment implements
                 return true;
         }
         return false;
-    }
-
-    @SuppressLint("CheckResult")
-    private void goToArtist() {
-        AlbumArtist currentAlbumArtist = mediaManager.getAlbumArtist();
-        // MediaManager.getAlbumArtist() is only populate with the album the current Song belongs to.
-        // Let's find the matching AlbumArtist in the DataManager.albumArtistRelay
-        DataManager.getInstance().getAlbumArtistsRelay()
-                .first(Collections.emptyList())
-                .flatMapObservable(Observable::fromIterable)
-                .filter(albumArtist -> currentAlbumArtist != null && albumArtist.name.equals(currentAlbumArtist.name) && albumArtist.albums.containsAll(currentAlbumArtist.albums))
-                .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(
-                        albumArtist -> navigationEventRelay.sendEvent(new NavigationEventRelay.NavigationEvent(NavigationEventRelay.NavigationEvent.Type.GO_TO_ARTIST, albumArtist, true)),
-                        error -> LogUtils.logException(TAG, "goToArtist error", error)
-                );
-    }
-
-    private void goToAlbum() {
-        navigationEventRelay.sendEvent(new NavigationEventRelay.NavigationEvent(NavigationEventRelay.NavigationEvent.Type.GO_TO_ALBUM, mediaManager.getAlbum(), true));
-    }
-
-    @SuppressLint("CheckResult")
-    private void goToGenre() {
-        mediaManager.getGenre()
-                .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(
-                        (UnsafeConsumer<Genre>) genre -> navigationEventRelay.sendEvent(new NavigationEventRelay.NavigationEvent(NavigationEventRelay.NavigationEvent.Type.GO_TO_GENRE, genre, true)),
-                        error -> LogUtils.logException(TAG, "Error retrieving genre", error)
-                );
     }
 
     void animateColors(@NonNull ColorSet from, @NonNull ColorSet to, int duration, @NonNull UnsafeConsumer<ColorSet> consumer, @Nullable UnsafeAction onComplete) {

--- a/app/src/main/java/com/simplecity/amp_library/ui/fragments/SongFragment.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/fragments/SongFragment.java
@@ -268,7 +268,7 @@ public class SongFragment extends BaseFragment implements
     @Override
     public void onSongOverflowClick(int position, View view, Song song) {
         PopupMenu menu = new PopupMenu(getContext(), view);
-        SongMenuUtils.INSTANCE.setupSongMenu(menu, false);
+        SongMenuUtils.INSTANCE.setupSongMenu(menu, false, true, true);
         menu.setOnMenuItemClickListener(SongMenuUtils.INSTANCE.getSongMenuClickListener(song, songMenuCallbacksAdapter));
         menu.show();
     }

--- a/app/src/main/java/com/simplecity/amp_library/ui/fragments/SuggestedFragment.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/fragments/SuggestedFragment.java
@@ -92,7 +92,7 @@ public class SuggestedFragment extends BaseFragment implements
         @Override
         public void onSongOverflowClicked(View v, int position, Song song) {
             PopupMenu popupMenu = new PopupMenu(getContext(), v);
-            SongMenuUtils.INSTANCE.setupSongMenu(popupMenu, false);
+            SongMenuUtils.INSTANCE.setupSongMenu(popupMenu, false, true, true);
             popupMenu.setOnMenuItemClickListener(SongMenuUtils.INSTANCE.getSongMenuClickListener(song, songMenuCallbacksAdapter));
             popupMenu.show();
         }
@@ -427,7 +427,7 @@ public class SuggestedFragment extends BaseFragment implements
     @Override
     public void onAlbumOverflowClicked(View v, Album album) {
         PopupMenu menu = new PopupMenu(getContext(), v);
-        AlbumMenuUtils.INSTANCE.setupAlbumMenu(menu);
+        AlbumMenuUtils.INSTANCE.setupAlbumMenu(menu, true);
         menu.setOnMenuItemClickListener(AlbumMenuUtils.INSTANCE.getAlbumMenuClickListener(getContext(), mediaManager, album, albumMenuCallbacksAdapter));
         menu.show();
     }

--- a/app/src/main/java/com/simplecity/amp_library/ui/queue/QueueFragment.kt
+++ b/app/src/main/java/com/simplecity/amp_library/ui/queue/QueueFragment.kt
@@ -39,6 +39,7 @@ import com.simplecity.amp_library.utils.PlaylistUtils
 import com.simplecity.amp_library.utils.ResourceUtils
 import com.simplecity.amp_library.utils.ShuttleUtils
 import com.simplecity.amp_library.utils.StringUtils
+import com.simplecity.amp_library.utils.menu.MenuUtils
 import com.simplecity.amp_library.utils.menu.queue.QueueMenuUtils
 import com.simplecity.amp_library.utils.menu.song.SongMenuCallbacksAdapter
 import com.simplecity.multisheetview.ui.view.MultiSheetView
@@ -107,6 +108,18 @@ class QueueFragment : BaseFragment(), QueueContract.View {
 
             override fun removeQueueItems(queueItems: Single<List<QueueItem>>) {
                 queuePresenter.removeFromQueue(queueItems)
+            }
+
+            override fun goToArtist(song: Song) {
+                MenuUtils.goToArtist(song.albumArtist, navigationEventRelay)
+            }
+
+            override fun goToAlbum(song: Song) {
+                MenuUtils.goToAlbum(song.album, navigationEventRelay)
+            }
+
+            override fun goToGenre(song: Song) {
+                MenuUtils.goToGenre(song.genre, navigationEventRelay)
             }
         }
 

--- a/app/src/main/java/com/simplecity/amp_library/utils/menu/MenuUtils.java
+++ b/app/src/main/java/com/simplecity/amp_library/utils/menu/MenuUtils.java
@@ -4,6 +4,10 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.support.annotation.NonNull;
 import android.view.MenuItem;
+
+import com.simplecity.amp_library.model.Album;
+import com.simplecity.amp_library.model.AlbumArtist;
+import com.simplecity.amp_library.model.Genre;
 import com.simplecity.amp_library.model.InclExclItem;
 import com.simplecity.amp_library.model.Playlist;
 import com.simplecity.amp_library.model.Song;
@@ -11,13 +15,19 @@ import com.simplecity.amp_library.playback.MediaManager;
 import com.simplecity.amp_library.rx.UnsafeAction;
 import com.simplecity.amp_library.rx.UnsafeConsumer;
 import com.simplecity.amp_library.sql.databases.InclExclHelper;
+import com.simplecity.amp_library.ui.drawer.NavigationEventRelay;
+import com.simplecity.amp_library.utils.DataManager;
 import com.simplecity.amp_library.utils.LogUtils;
 import com.simplecity.amp_library.utils.PlaylistUtils;
+
+import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 import java.util.Collections;
 import java.util.List;
+
+import io.reactivex.schedulers.Schedulers;
 import kotlin.Unit;
 
 public class MenuUtils {
@@ -97,6 +107,37 @@ public class MenuUtils {
                 .subscribe(
                         MenuUtils::blacklist,
                         throwable -> LogUtils.logException(TAG, "blacklist failed", throwable)
+                );
+    }
+
+    @SuppressLint("CheckResult")
+    public static void goToArtist(AlbumArtist currentAlbumArtist, NavigationEventRelay navigationEventRelay) {
+        // MediaManager.getAlbumArtist() is only populate with the album the current Song belongs to.
+        // Let's find the matching AlbumArtist in the DataManager.albumArtistRelay
+        DataManager.getInstance().getAlbumArtistsRelay()
+                .first(Collections.emptyList())
+                .flatMapObservable(Observable::fromIterable)
+                .filter(albumArtist -> currentAlbumArtist != null && albumArtist.name.equals(currentAlbumArtist.name) && albumArtist.albums.containsAll(currentAlbumArtist.albums))
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(
+                        albumArtist -> navigationEventRelay.sendEvent(new NavigationEventRelay.NavigationEvent(NavigationEventRelay.NavigationEvent.Type.GO_TO_ARTIST, albumArtist, true)),
+                        error -> LogUtils.logException(TAG, "goToArtist error", error)
+                );
+    }
+
+    public static void goToAlbum(Album album, NavigationEventRelay navigationEventRelay) {
+        navigationEventRelay.sendEvent(new NavigationEventRelay.NavigationEvent(NavigationEventRelay.NavigationEvent.Type.GO_TO_ALBUM, album, true));
+    }
+
+    @SuppressLint("CheckResult")
+    public static void goToGenre(Single<Genre> genreSingle, NavigationEventRelay navigationEventRelay) {
+        genreSingle
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(
+                        (UnsafeConsumer<Genre>) genre -> navigationEventRelay.sendEvent(new NavigationEventRelay.NavigationEvent(NavigationEventRelay.NavigationEvent.Type.GO_TO_GENRE, genre, true)),
+                        error -> LogUtils.logException(TAG, "Error retrieving genre", error)
                 );
     }
 

--- a/app/src/main/java/com/simplecity/amp_library/utils/menu/album/AlbumMenuCallbacksAdapter.kt
+++ b/app/src/main/java/com/simplecity/amp_library/utils/menu/album/AlbumMenuCallbacksAdapter.kt
@@ -9,6 +9,7 @@ import com.simplecity.amp_library.ui.dialog.DeleteDialog
 import com.simplecity.amp_library.ui.dialog.UpgradeDialog
 import com.simplecity.amp_library.ui.fragments.BaseFragment
 import com.simplecity.amp_library.utils.ArtworkDialog
+import com.simplecity.amp_library.utils.menu.MenuUtils
 import io.reactivex.Single
 import io.reactivex.disposables.CompositeDisposable
 
@@ -58,5 +59,9 @@ class AlbumMenuCallbacksAdapter(val fragment: BaseFragment, val disposables: Com
 
     override fun showToast(message: String) {
         Toast.makeText(fragment.context, message, Toast.LENGTH_LONG).show()
+    }
+
+    override fun goToArtist(album: Album) {
+        MenuUtils.goToArtist(album.albumArtist, fragment.navigationEventRelay)
     }
 }

--- a/app/src/main/java/com/simplecity/amp_library/utils/menu/album/AlbumMenuUtils.kt
+++ b/app/src/main/java/com/simplecity/amp_library/utils/menu/album/AlbumMenuUtils.kt
@@ -40,10 +40,16 @@ object AlbumMenuUtils {
         fun showUpgradeDialog()
 
         fun showToast(message: String)
+
+        fun goToArtist(album: Album)
     }
 
-    fun setupAlbumMenu(menu: PopupMenu) {
+    fun setupAlbumMenu(menu: PopupMenu, showGoToArtist: Boolean = true) {
         menu.inflate(R.menu.menu_album)
+
+        if (!showGoToArtist) {
+            menu.menu.findItem(R.id.go_to).isVisible = false
+        }
 
         // Add playlist menu
         val sub = menu.menu.findItem(R.id.addToPlaylist).subMenu
@@ -127,6 +133,10 @@ object AlbumMenuUtils {
                 }
                 R.id.delete -> {
                     callbacks.showDeleteDialog(album)
+                    return@OnMenuItemClickListener true
+                }
+                R.id.goToArtist -> {
+                    callbacks.goToArtist(album)
                     return@OnMenuItemClickListener true
                 }
             }

--- a/app/src/main/java/com/simplecity/amp_library/utils/menu/queue/QueueMenuUtils.kt
+++ b/app/src/main/java/com/simplecity/amp_library/utils/menu/queue/QueueMenuUtils.kt
@@ -100,6 +100,18 @@ object QueueMenuUtils {
                     callbacks.removeQueueItem(queueItem)
                     return@OnMenuItemClickListener true
                 }
+                R.id.goToAlbum -> {
+                    callbacks.goToAlbum(queueItem.song)
+                    return@OnMenuItemClickListener true
+                }
+                R.id.goToArtist -> {
+                    callbacks.goToArtist(queueItem.song)
+                    return@OnMenuItemClickListener true
+                }
+                R.id.goToGenre -> {
+                    callbacks.goToGenre(queueItem.song)
+                    return@OnMenuItemClickListener true
+                }
             }
             false
         }

--- a/app/src/main/java/com/simplecity/amp_library/utils/menu/song/SongMenuCallbacksAdapter.kt
+++ b/app/src/main/java/com/simplecity/amp_library/utils/menu/song/SongMenuCallbacksAdapter.kt
@@ -113,4 +113,15 @@ open class SongMenuCallbacksAdapter(val fragment: BaseFragment, val disposables:
         MenuUtils.addToPlaylist(fragment.context, playlist, songs, { onPlaylistItemsInserted(songs) })
     }
 
+    override fun goToArtist(song: Song) {
+        MenuUtils.goToArtist(song.albumArtist, fragment.navigationEventRelay)
+    }
+
+    override fun goToAlbum(song: Song) {
+        MenuUtils.goToAlbum(song.album, fragment.navigationEventRelay)
+    }
+
+    override fun goToGenre(song: Song) {
+        MenuUtils.goToGenre(song.genre, fragment.navigationEventRelay)
+    }
 }

--- a/app/src/main/java/com/simplecity/amp_library/utils/menu/song/SongMenuUtils.kt
+++ b/app/src/main/java/com/simplecity/amp_library/utils/menu/song/SongMenuUtils.kt
@@ -46,6 +46,12 @@ object SongMenuUtils {
         fun removeSong(song: Song)
 
         fun showDeleteDialog(song: Song)
+
+        fun goToArtist(song: Song)
+
+        fun goToAlbum(song: Song)
+
+        fun goToGenre(song: Song)
     }
 
     interface SongListCallbacks {
@@ -75,11 +81,24 @@ object SongMenuUtils {
         fun showDeleteDialog(songs: Single<List<Song>>)
     }
 
-    fun setupSongMenu(menu: PopupMenu, showRemoveButton: Boolean) {
+    fun setupSongMenu(
+            menu: PopupMenu,
+            showRemoveButton: Boolean,
+            showGoToAlbum: Boolean = true,
+            showGoToArtist: Boolean = true
+    ) {
         menu.inflate(R.menu.menu_song)
 
         if (!showRemoveButton) {
             menu.menu.findItem(R.id.remove).isVisible = false
+        }
+
+        if (!showGoToAlbum) {
+            menu.menu.findItem(R.id.goToAlbum).isVisible = false
+        }
+
+        if (!showGoToArtist) {
+            menu.menu.findItem(R.id.goToArtist).isVisible = false
         }
 
         // Add playlist menu
@@ -164,6 +183,18 @@ object SongMenuUtils {
                 }
                 R.id.remove -> {
                     callbacks.removeSong(song)
+                    return@OnMenuItemClickListener true
+                }
+                R.id.goToAlbum -> {
+                    callbacks.goToAlbum(song)
+                    return@OnMenuItemClickListener true
+                }
+                R.id.goToArtist -> {
+                    callbacks.goToArtist(song)
+                    return@OnMenuItemClickListener true
+                }
+                R.id.goToGenre -> {
+                    callbacks.goToGenre(song)
                     return@OnMenuItemClickListener true
                 }
             }

--- a/app/src/main/res/menu/menu_album.xml
+++ b/app/src/main/res/menu/menu_album.xml
@@ -45,4 +45,14 @@
         android:id="@+id/delete"
         android:title="@string/delete_item" />
 
+    <item
+        android:id="@+id/go_to"
+        android:title="@string/go_to">
+        <menu>
+            <item
+                android:id="@+id/goToArtist"
+                android:title="@string/artist_title"/>
+        </menu>
+    </item>
+
 </menu>

--- a/app/src/main/res/menu/menu_song.xml
+++ b/app/src/main/res/menu/menu_song.xml
@@ -49,4 +49,21 @@
         android:id="@+id/delete"
         android:title="@string/delete_item"/>
 
+    <item
+        android:title="@string/go_to">
+        <menu>
+            <item
+                android:id="@+id/goToArtist"
+                android:title="@string/artist_title"/>
+
+            <item
+                android:id="@+id/goToAlbum"
+                android:title="@string/album_title"/>
+
+            <item
+                android:id="@+id/goToGenre"
+                android:title="@string/genre_title"/>
+        </menu>
+    </item>
+
 </menu>


### PR DESCRIPTION
(Originally requested at https://www.reddit.com/r/shuttle/comments/9bpjd7/feature_request_add_go_to_option_to_items_in/)

This adds the "Go to" menu item found on the now playing screen to other areas of the app, such as search and the library.  Depending on the media type (album/artist/song) and screen that the user is on, one or more of artist, album, and genre will be displayed in the "Go to" menu.