### PR TITLE
Swipe to remove from queue

### DIFF
--- a/app/src/main/java/com/simplecity/amp_library/ui/adapters/ViewType.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/adapters/ViewType.java
@@ -55,4 +55,6 @@ public @interface ViewType {
     int SUBHEADER = 33;
 
     int SHUFFLE_ALBUMS = 34;
+
+    int SUBHEADERLOCK = 35;
 }

--- a/app/src/main/java/com/simplecity/amp_library/ui/detail/playlist/PlaylistDetailFragment.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/detail/playlist/PlaylistDetailFragment.java
@@ -590,6 +590,9 @@ public class PlaylistDetailFragment extends BaseFragment implements
             },
             () -> {
                 // Nothing to do
+            },
+            (pos) -> {
+
             }) {
         @Override
         public boolean onMove(RecyclerView recyclerView, RecyclerView.ViewHolder viewHolder, RecyclerView.ViewHolder target) {

--- a/app/src/main/java/com/simplecity/amp_library/ui/dialog/TabChooserDialog.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/dialog/TabChooserDialog.java
@@ -42,6 +42,8 @@ public class TabChooserDialog {
                         (fromPosition, toPosition) -> {
                         },
                         () -> {
+                        },
+                        (pos) -> {
                         }
                 ));
 

--- a/app/src/main/java/com/simplecity/amp_library/ui/modelviews/SubheaderLockView.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/modelviews/SubheaderLockView.java
@@ -1,0 +1,116 @@
+package com.simplecity.amp_library.ui.modelviews;
+
+import android.support.annotation.Nullable;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageButton;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.simplecityapps.recycler_adapter.model.BaseViewModel;
+import com.simplecityapps.recycler_adapter.recyclerview.BaseViewHolder;
+
+import java.util.List;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+
+import static com.simplecity.amp_library.R.id;
+import static com.simplecity.amp_library.R.layout.list_item_subheader;
+import static com.simplecity.amp_library.R.layout.list_item_subheader_lock;
+import static com.simplecity.amp_library.ui.adapters.ViewType.SUBHEADER;
+import static com.simplecity.amp_library.ui.adapters.ViewType.SUBHEADERLOCK;
+
+public class SubheaderLockView extends BaseViewModel<SubheaderLockView.ViewHolder> {
+
+    public interface ClickListener {
+        void onSubheaderLockClick(ImageView subHeaderLock);
+    }
+
+    private ImageView subHeaderLock;
+    protected String title;
+
+    @Nullable
+    private ClickListener listener;
+
+    public SubheaderLockView(String title) {
+        this.title = title;
+    }
+
+    public void setClickListener(@Nullable ClickListener listener) {
+        this.listener = listener;
+    }
+
+    void onClick() {
+        if (listener != null) {
+            listener.onSubheaderLockClick(subHeaderLock);
+        }
+    }
+
+    @Override
+    public int getViewType() {
+        return SUBHEADERLOCK;
+    }
+
+    @Override
+    public int getLayoutResId() {
+        return list_item_subheader_lock;
+    }
+
+    @Override
+    public ViewHolder createViewHolder(ViewGroup parent) {
+        return new ViewHolder(createView(parent));
+    }
+
+    @Override
+    public void bindView(ViewHolder holder) {
+        super.bindView(holder);
+
+        holder.textView.setText(title);
+    }
+
+    @Override
+    public void bindView(ViewHolder holder, int position, List payloads) {
+        super.bindView(holder, position, payloads);
+
+        holder.textView.setText(title);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        SubheaderLockView that = (SubheaderLockView) o;
+
+        return title != null ? title.equals(that.title) : that.title == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return title != null ? title.hashCode() : 0;
+    }
+
+    @Override
+    public boolean areContentsEqual(Object other) {
+
+        if (other instanceof SubheaderLockView) {
+            return ((SubheaderLockView) other).title.equals(title);
+        }
+
+        return false;
+    }
+
+    public static class ViewHolder extends BaseViewHolder<SubheaderLockView> {
+
+        @BindView(id.textView)
+        TextView textView;
+
+        public ViewHolder(View itemView) {
+            super(itemView);
+
+            ButterKnife.bind(this, itemView);
+            itemView.setOnClickListener(v -> viewModel.onClick());
+        }
+    }
+}

--- a/app/src/main/java/com/simplecity/amp_library/ui/queue/QueueFragment.kt
+++ b/app/src/main/java/com/simplecity/amp_library/ui/queue/QueueFragment.kt
@@ -26,7 +26,7 @@ import com.simplecity.amp_library.ui.dialog.DeleteDialog
 import com.simplecity.amp_library.ui.dialog.UpgradeDialog
 import com.simplecity.amp_library.ui.fragments.BaseFragment
 import com.simplecity.amp_library.ui.modelviews.SelectableViewModel
-import com.simplecity.amp_library.ui.modelviews.SubheaderView
+import com.simplecity.amp_library.ui.modelviews.SubheaderLockView
 import com.simplecity.amp_library.ui.presenters.PlayerPresenter
 import com.simplecity.amp_library.ui.recyclerview.ItemTouchHelperCallback
 import com.simplecity.amp_library.ui.views.ContextualToolbar
@@ -56,6 +56,7 @@ import kotlinx.android.synthetic.main.fragment_queue.line2
 import kotlinx.android.synthetic.main.fragment_queue.recyclerView
 import kotlinx.android.synthetic.main.fragment_queue.statusBarView
 import kotlinx.android.synthetic.main.fragment_queue.toolbar
+import kotlinx.android.synthetic.main.list_item_subheader_lock.*
 import java.util.ArrayList
 import javax.inject.Inject
 
@@ -83,9 +84,13 @@ class QueueFragment : BaseFragment(), QueueContract.View {
 
     private lateinit var itemTouchHelper: ItemTouchHelper
 
+    private lateinit var itemTouchHelperCallback : ItemTouchHelperCallback
+
     private lateinit var cabToolbar: ContextualToolbar
 
     private lateinit var cabHelper: ContextualToolbarHelper<QueueItem>
+
+    private var locked : Boolean = true
 
     // Lifecycle
 
@@ -134,30 +139,36 @@ class QueueFragment : BaseFragment(), QueueContract.View {
         recyclerView.setRecyclerListener(RecyclerListener())
         recyclerView.adapter = adapter
 
-        itemTouchHelper = ItemTouchHelper(object : ItemTouchHelperCallback(
+        itemTouchHelperCallback = object : ItemTouchHelperCallback(
             { fromPosition, toPosition -> adapter.moveItem(fromPosition, toPosition) },
             { from, to ->
                 val numBeforeFrom = (0..from)
-                    .map { value -> adapter.items[value] }
-                    .filter { value -> value !is QueueViewBinder }
-                    .count()
+                        .map { value -> adapter.items[value] }
+                        .filter { value -> value !is QueueViewBinder }
+                        .count()
 
                 val numBeforeTo = (0..to)
-                    .map { value -> adapter.items[value] }
-                    .filter { value -> value !is QueueViewBinder }
-                    .count()
+                        .map { value -> adapter.items[value] }
+                        .filter { value -> value !is QueueViewBinder }
+                        .count()
 
                 mediaManager.moveQueueItem(from - numBeforeFrom, to - numBeforeTo)
             },
             {
                 // Nothing to do
+            },
+            {
+                pos -> queuePresenter.removeFromQueue((adapter.items[pos] as QueueViewBinder).queueItem)
+                adapter.removeItem(pos)
             }) {
             override fun onMove(recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder, target: RecyclerView.ViewHolder): Boolean {
                 return if (viewHolder.itemViewType == target.itemViewType) {
                     super.onMove(recyclerView, viewHolder, target)
                 } else false
             }
-        })
+        }
+
+        itemTouchHelper = ItemTouchHelper(itemTouchHelperCallback)
 
         itemTouchHelper.attachToRecyclerView(recyclerView)
 
@@ -311,6 +322,19 @@ class QueueFragment : BaseFragment(), QueueContract.View {
                         queueItems.map { queueItem -> queueItem.song.duration / 1000 }.sum()
                     )
                 )
+                queueHeaderView.setClickListener{
+                    if(locked) {
+                        showToast("Unlocked swipe to delete", Toast.LENGTH_SHORT)
+                        locked = false
+                        itemTouchHelperCallback.changeSwipeState()
+                        imageView.setImageResource(R.drawable.ic_unlock_24dp)
+                    } else {
+                        showToast("Locked swipe to delete", Toast.LENGTH_SHORT)
+                        locked = true
+                        itemTouchHelperCallback.changeSwipeState()
+                        imageView.setImageResource(R.drawable.ic_lock_24dp)
+                    }
+                }
 
                 val viewModels = ArrayList<ViewModel<*>>()
                 viewModels.add(queueHeaderView)
@@ -409,7 +433,7 @@ class QueueFragment : BaseFragment(), QueueContract.View {
         }
     }
 
-    class QueueHeaderView(title: String) : SubheaderView(title) {
+    class QueueHeaderView(title: String) : SubheaderLockView(title) {
 
         override fun equals(other: Any?): Boolean {
             if (this === other) return true

--- a/app/src/main/java/com/simplecity/amp_library/ui/recyclerview/ItemTouchHelperCallback.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/recyclerview/ItemTouchHelperCallback.java
@@ -8,6 +8,7 @@ public class ItemTouchHelperCallback extends ItemTouchHelper.Callback {
 
     private int startPosition = -1;
     private int endPosition = -1;
+    private boolean isSwipable = false;
 
     public interface OnItemMoveListener {
         void onItemMove(int fromPosition, int toPosition);
@@ -21,21 +22,31 @@ public class ItemTouchHelperCallback extends ItemTouchHelper.Callback {
         void onClear();
     }
 
+    public interface OnSwipeListener {
+        void onSwipe(int pos);
+    }
+
     private OnItemMoveListener mItemMoveListener;
     private OnDropListener mOnDropListener;
 
     @Nullable
     private OnClearListener mOnClearListener;
+    private OnSwipeListener mOnSwipeListener;
 
-    public ItemTouchHelperCallback(OnItemMoveListener onMoveListener, OnDropListener onDropListener, @Nullable OnClearListener onClearListener) {
+    public ItemTouchHelperCallback(OnItemMoveListener onMoveListener, OnDropListener onDropListener, @Nullable OnClearListener onClearListener, OnSwipeListener onSwipeListener) {
         mItemMoveListener = onMoveListener;
         mOnDropListener = onDropListener;
         mOnClearListener = onClearListener;
+        mOnSwipeListener = onSwipeListener;
     }
 
     @Override
     public boolean isItemViewSwipeEnabled() {
-        return false;
+        return isSwipable;
+    }
+
+    public void changeSwipeState() {
+        isSwipable = !isSwipable;
     }
 
     @Override
@@ -57,7 +68,7 @@ public class ItemTouchHelperCallback extends ItemTouchHelper.Callback {
 
     @Override
     public void onSwiped(RecyclerView.ViewHolder viewHolder, int direction) {
-        //Nothing endPosition do
+        mOnSwipeListener.onSwipe(viewHolder.getAdapterPosition());
     }
 
     @Override

--- a/app/src/main/res/drawable/ic_lock_24dp.xml
+++ b/app/src/main/res/drawable/ic_lock_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M18,8h-1L17,6c0,-2.76 -2.24,-5 -5,-5S7,3.24 7,6v2L6,8c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L20,10c0,-1.1 -0.9,-2 -2,-2zM12,17c-1.1,0 -2,-0.9 -2,-2s0.9,-2 2,-2 2,0.9 2,2 -0.9,2 -2,2zM15.1,8L8.9,8L8.9,6c0,-1.71 1.39,-3.1 3.1,-3.1 1.71,0 3.1,1.39 3.1,3.1v2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_unlock_24dp.xml
+++ b/app/src/main/res/drawable/ic_unlock_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M12,17c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM18,8h-1L17,6c0,-2.76 -2.24,-5 -5,-5S7,3.24 7,6h1.9c0,-1.71 1.39,-3.1 3.1,-3.1 1.71,0 3.1,1.39 3.1,3.1v2L6,8c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L20,10c0,-1.1 -0.9,-2 -2,-2zM18,20L6,20L6,10h12v10z"/>
+</vector>

--- a/app/src/main/res/layout/list_item_subheader_lock.xml
+++ b/app/src/main/res/layout/list_item_subheader_lock.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="48dp"
+    android:paddingEnd="16dp"
+    android:paddingStart="16dp">
+
+    <ImageView
+        android:id="@+id/imageView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:srcCompat="@drawable/ic_lock_24dp"
+        android:layout_gravity="end|center"/>
+
+    <TextView
+        android:id="@+id/textView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center_vertical"
+        android:textColor="?android:textColorSecondary"
+        android:textSize="14sp"
+        tools:text="Subheader"/>
+
+
+</FrameLayout>


### PR DESCRIPTION
This resolves #361 by adding a lock icon to the queue fragment to lock and unlock swiping functionality. When unlocked, songs can be swiped from the queue to be removed.