### PR TITLE
Color the inactive scroll thumb

### DIFF
--- a/app/src/main/java/com/simplecity/amp_library/ui/views/AestheticFastScrollRecyclerView.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/views/AestheticFastScrollRecyclerView.java
@@ -29,6 +29,7 @@ public class AestheticFastScrollRecyclerView extends FastScrollRecyclerView {
         super.onAttachedToWindow();
         aestheticDisposable = Aesthetic.get(getContext()).colorAccent().subscribe(color -> {
             setThumbColor(color);
+            setThumbInactiveColor(color);
             setPopupBgColor(color);
             setPopupTextColor(Util.isColorLight(color) ? Color.BLACK : Color.WHITE);
         });


### PR DESCRIPTION
Should fix #420 
This just colors the thumb with accent color when scrolling without pop-up.This makes it easier to spot the track before it autohides
[Screenshots](https://imgur.com/a/mgRwsjk)