### PR TITLE
Remove Google+ link from Support page

### DIFF
--- a/app/src/main/java/com/simplecity/amp_library/ui/settings/SettingsParentFragment.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/settings/SettingsParentFragment.java
@@ -203,14 +203,6 @@ public class SettingsParentFragment extends BaseNavigationController implements
                 });
             }
 
-            Preference helpPreference = findPreference(SettingsManager.KEY_PREF_HELP);
-            if (helpPreference != null) {
-                helpPreference.setOnPreferenceClickListener(preference -> {
-                    supportPresenter.helpClicked();
-                    return true;
-                });
-            }
-
             Preference ratePreference = findPreference(SettingsManager.KEY_PREF_RATE);
             if (ratePreference != null) {
                 ratePreference.setOnPreferenceClickListener(preference -> {
@@ -490,11 +482,6 @@ public class SettingsParentFragment extends BaseNavigationController implements
 
         @Override
         public void showFaq(Intent intent) {
-            startActivity(intent);
-        }
-
-        @Override
-        public void showHelp(Intent intent) {
             startActivity(intent);
         }
 

--- a/app/src/main/java/com/simplecity/amp_library/ui/settings/SupportPresenter.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/settings/SupportPresenter.java
@@ -45,14 +45,6 @@ public class SupportPresenter extends Presenter<SupportView> {
         }
     }
 
-    public void helpClicked() {
-        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://plus.google.com/communities/112365043563095486408"));
-        SupportView supportView = getView();
-        if (supportView != null) {
-            supportView.showHelp(intent);
-        }
-    }
-
     public void rateClicked() {
 
         settingsManager.setHasRated();

--- a/app/src/main/java/com/simplecity/amp_library/ui/settings/SupportView.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/settings/SupportView.java
@@ -8,7 +8,5 @@ public interface SupportView {
 
     void showFaq(Intent intent);
 
-    void showHelp(Intent intent);
-
     void showRate(Intent intent);
 }

--- a/app/src/main/java/com/simplecity/amp_library/utils/SettingsManager.java
+++ b/app/src/main/java/com/simplecity/amp_library/utils/SettingsManager.java
@@ -25,7 +25,6 @@ public class SettingsManager extends BaseSettingsManager {
     // Support
     public static String KEY_PREF_CHANGELOG = "pref_changelog";
     public static String KEY_PREF_FAQ = "pref_faq";
-    public static String KEY_PREF_HELP = "pref_help";
     public static String KEY_PREF_RATE = "pref_rate";
     public static String KEY_PREF_RESTORE_PURCHASES = "pref_restore_purchases";
 

--- a/app/src/main/res/xml/settings_support.xml
+++ b/app/src/main/res/xml/settings_support.xml
@@ -19,11 +19,6 @@
             android:title="@string/pref_title_faq"/>
 
         <android.support.v7.preference.Preference
-            android:key="pref_help"
-            android:summary="@string/pref_summary_gplus"
-            android:title="@string/pref_title_gplus"/>
-
-        <android.support.v7.preference.Preference
             android:key="pref_rate"
             android:summary="@string/pref_summary_rate"
             android:title="@string/pref_title_rate"/>


### PR DESCRIPTION
Google+ shut down on April 2nd 2019. The community on Google+ doesn't exist anymore.