### PR TITLE
Fix up the link to community

### DIFF
--- a/app/src/main/java/com/simplecity/amp_library/ui/settings/SupportPresenter.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/settings/SupportPresenter.java
@@ -46,7 +46,7 @@ public class SupportPresenter extends Presenter<SupportView> {
     }
 
     public void helpClicked() {
-        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://plus.google.com/communities/112365043563095486408"));
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://discordapp.com/channels/499448243491569673"));
         SupportView supportView = getView();
         if (supportView != null) {
             supportView.showHelp(intent);

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -361,8 +361,8 @@
     <string name="pref_title_version">Версия</string>
     <string name="pref_title_faq">ЧЗВ</string>
     <string name="pref_summary_faq">Имате въпрос или нужда от помощ? Докоснете тук, за да отворите списъка с въпроси и отговори на www.shuttlemusicplayer.com</string>
-    <string name="pref_title_gplus">Помощ</string>
-    <string name="pref_summary_gplus">В Google+ е налице е много активна общност от потребители на Shuttle. Ако имате въпроси или нужда от помощ, най-добре да посетите общността.</string>
+    <string name="pref_title_community">Помощ</string>
+    <string name="pref_summary_community">В Google+ е налице е много активна общност от потребители на Shuttle. Ако имате въпроси или нужда от помощ, най-добре да посетите общността.</string>
     <string name="pref_title_rate">Кажете \"Благодаря\"</string>
     <string name="pref_summary_rate">Ако харесвате Shuttle, обмислете написването на ревю.</string>
     <!-- Settings title for ignore playlist duplicates -->

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -344,8 +344,8 @@ Si està desmarcat, s\'emprarà l\'icona de Shuttle.</string>
     <string name="pref_title_version">Versió</string>
     <string name="pref_title_faq">FAQ</string>
     <string name="pref_summary_faq">Tens cap pregunta? Necessites ajuda? Clica aquí per veure les FAQ @www.shuttlemusicplayer.com</string>
-    <string name="pref_title_gplus">Rebre ajuda</string>
-    <string name="pref_summary_gplus">Existeix una comunitat molt activa d\'usuaris de Shuttle a Google+. Si tens cap pregunta o necessites ajuda, aquest és el millor lloc on anar.</string>
+    <string name="pref_title_community">Rebre ajuda</string>
+    <string name="pref_summary_community">Existeix una comunitat molt activa d\'usuaris de Shuttle a Google+. Si tens cap pregunta o necessites ajuda, aquest és el millor lloc on anar.</string>
     <string name="pref_title_rate">Dóna les gràcies</string>
     <string name="pref_summary_rate">Si t\'agrada Shuttle, sisplau considera fer-ne una ressenya.</string>
     <!-- Settings title for ignore playlist duplicates -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -389,8 +389,8 @@
     <string name="pref_title_version">Version</string>
     <string name="pref_title_faq">FAQ</string>
     <string name="pref_summary_faq">Du hast eine Frage oder brauchst Hilfe? Klicke hier für die FAQ @ www.shuttlemusicplayer.com.</string>
-    <string name="pref_title_gplus">Hilfe</string>
-    <string name="pref_summary_gplus">Shuttle hat eine sehr aktive Community auf Google+. Für Fragen oder Hilfe ist dies der beste Ort.</string>
+    <string name="pref_title_community">Hilfe</string>
+    <string name="pref_summary_community">Shuttle hat eine sehr aktive Community auf Google+. Für Fragen oder Hilfe ist dies der beste Ort.</string>
     <string name="pref_title_rate">Danke sagen</string>
     <string name="pref_summary_rate">Gib bitte eine Bewertung ab, wenn dir Shuttle gefällt.</string>
     <string name="pref_title_headset_beep">Ton beim Überspringen</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -369,8 +369,8 @@ Si no está seleccionado, se usará el icono de Shuttle en su lugar</string>
     <string name="pref_title_version">Versión</string>
     <string name="pref_title_faq">FAQ</string>
     <string name="pref_summary_faq">¿Tienes una pregunta? ¿Necesitas ayuda? Haz click aquí para ver el FAQ en www.shuttlemusicplayer.com</string>
-    <string name="pref_title_gplus">Conseguir ayuda</string>
-    <string name="pref_summary_gplus">Esta es una comunidad muy activa de usuarios de Shuttle en Google+. Si usted tiene preguntas o necesita ayuda, este es el mejor lugar al que acudir.</string>
+    <string name="pref_title_community">Conseguir ayuda</string>
+    <string name="pref_summary_community">Esta es una comunidad muy activa de usuarios de Shuttle en Google+. Si usted tiene preguntas o necesita ayuda, este es el mejor lugar al que acudir.</string>
     <string name="pref_title_rate">Da las gracias</string>
     <string name="pref_summary_rate">Si te gusta Shuttle, por favor considera dejar una crítica.</string>
     <string name="pref_title_headset_beep">Pitar al pasar</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -374,8 +374,8 @@
     <string name="pref_title_version">"Versión "</string>
     <string name="pref_title_faq">"FAQ "</string>
     <string name="pref_summary_faq">"¿Tienes alguna pregunta? ¿Necesitas ayuda? Has click aquí para ver el FAQ (Preguntas frecuentes) @ www.shuttlemusicplayer.com "</string>
-    <string name="pref_title_gplus">¡Ayuda!</string>
-    <string name="pref_summary_gplus">Hay una muy activa comunidad de usuarios de Shuttle en Google+. Si tiene preguntas o necesita ayuda, este es el mejor lugar para ir</string>
+    <string name="pref_title_community">¡Ayuda!</string>
+    <string name="pref_summary_community">Hay una muy activa comunidad de usuarios de Shuttle en Google+. Si tiene preguntas o necesita ayuda, este es el mejor lugar para ir</string>
     <string name="pref_title_rate">"Agradece "</string>
     <string name="pref_summary_rate">Si te gusta Shuttle, por favor considera dejar una reseña</string>
     <string name="pref_title_headset_beep">Pitido en Skip</string>

--- a/app/src/main/res/values-et-rEE/strings.xml
+++ b/app/src/main/res/values-et-rEE/strings.xml
@@ -382,8 +382,8 @@ Kui see on välja lülitatud, siis kasutatakse Shuttle ikooni kohatäitena.</str
     <string name="pref_title_version">Versioon</string>
     <string name="pref_title_faq">KKK</string>
     <string name="pref_summary_faq">On sul küsimus? Vajad abi? Vajuta siia, et näha www.shuttlemusicplayer.com KKK sektsiooni</string>
-    <string name="pref_title_gplus">Hangi abi</string>
-    <string name="pref_summary_gplus">Google Plusis on väga aktiivne Shuttle kasutajate kogukond. Kui sul on küsimusi või kui vajad abi, siis see on parim koht, kuhu minna.</string>
+    <string name="pref_title_community">Hangi abi</string>
+    <string name="pref_summary_community">Google Plusis on väga aktiivne Shuttle kasutajate kogukond. Kui sul on küsimusi või kui vajad abi, siis see on parim koht, kuhu minna.</string>
     <string name="pref_title_rate">Ütle \"aitäh\"</string>
     <string name="pref_summary_rate">Kui sulle meeldib Shuttle, palun kaalu arvustuse kirjutamist.</string>
     <string name="pref_title_headset_beep">Piiks vahelejätmisel</string>

--- a/app/src/main/res/values-eu-rES/strings.xml
+++ b/app/src/main/res/values-eu-rES/strings.xml
@@ -374,8 +374,8 @@ Desaktibatzen bada, Shuttle-en ikonoa erabiliko da bere ordez</string>
     <string name="pref_title_version">Bertsioa</string>
     <string name="pref_title_faq">FAQ</string>
     <string name="pref_summary_faq">Galdera bat daukazu? Sakatu hemen FAQ-a www.shuttlemusicplayer.com-en ikusteko</string>
-    <string name="pref_title_gplus">Laguntza lortu</string>
-    <string name="pref_summary_gplus">Shuttle-en erabiltzaile komunitate oso aktiboa dago Google+ plataforman. Galderak badituzu edota laguntza behar baduzu, hau da leku onena.</string>
+    <string name="pref_title_community">Laguntza lortu</string>
+    <string name="pref_summary_community">Shuttle-en erabiltzaile komunitate oso aktiboa dago Google+ plataforman. Galderak badituzu edota laguntza behar baduzu, hau da leku onena.</string>
     <string name="pref_title_rate">Eskerrak eman</string>
     <string name="pref_summary_rate">Shuttle gustokoa baduzu, mesedez pentsatu kritika bat idaztea.</string>
     <string name="pref_title_headset_beep">Soinua pasatzean</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -385,8 +385,8 @@
     <string name="pref_title_version">Version</string>
     <string name="pref_title_faq">FAQ</string>
     <string name="pref_summary_faq">Une question ? Besoin d\'aide ? Cliquez ici pour voir la FAQ sur www.shuttlemusicplayer.com</string>
-    <string name="pref_title_gplus">Obtenir de l\'aide</string>
-    <string name="pref_summary_gplus">Il y a une communauté très active d\'utilisateurs de Shuttle sur Google+. Si vous avez des questions ou besoin d\'aide, c\'est le meilleur endroit où aller.</string>
+    <string name="pref_title_community">Obtenir de l\'aide</string>
+    <string name="pref_summary_community">Il y a une communauté très active d\'utilisateurs de Shuttle sur Google+. Si vous avez des questions ou besoin d\'aide, c\'est le meilleur endroit où aller.</string>
     <string name="pref_title_rate">Dites Merci</string>
     <string name="pref_summary_rate">Si vous aimez Shuttle, merci d\'écrire une critique.</string>
     <string name="pref_title_headset_beep">Jouer un son au changement</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -386,8 +386,8 @@
     <string name="pref_title_version">संस्करण</string>
     <string name="pref_title_faq">FAQ</string>
     <string name="pref_summary_faq">एक सवाल है? मदद चाहिए? पूछे जाने वाले प्रश्न देखने के लिए यहां क्लिक करें @ www.shuttlemusicplayer.com</string>
-    <string name="pref_title_gplus">मदद लें</string>
-    <string name="pref_summary_gplus">Google+ पर शटल उपयोगकर्ताओं का एक बहुत ही सक्रिय समुदाय है यदि आपके पास कोई सवाल है या सहायता की आवश्यकता है, तो यह जाने का सबसे अच्छा स्थान है।</string>
+    <string name="pref_title_community">मदद लें</string>
+    <string name="pref_summary_community">Google+ पर शटल उपयोगकर्ताओं का एक बहुत ही सक्रिय समुदाय है यदि आपके पास कोई सवाल है या सहायता की आवश्यकता है, तो यह जाने का सबसे अच्छा स्थान है।</string>
     <string name="pref_summary_rate">यदि आप Shuttle पसंद करते हैं, तो रिव्यू छोड़ने पर विचार करें।</string>
     <string name="pref_title_headset_beep">स्किप करने पर बीप</string>
     <string name="pref_summary_headset_beep">हेडसेट नियंत्रण के माध्यम से गाना स्किप करते समय बीप करें</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -382,8 +382,8 @@ Ako nije označeno, Shuttle ikona će se koristiti kao sličica</string>
     <string name="pref_title_version">Verzija</string>
     <string name="pref_title_faq">Često postavljana pitanja</string>
     <string name="pref_summary_faq">Imate pitanja? Trebate pomoč? Pritisnite ovdje kako bi pričitali FAQ @ www.shuttlemusicplayer.com</string>
-    <string name="pref_title_gplus">Pronađite pomoć</string>
-    <string name="pref_summary_gplus">Postoji vrlo aktivna zajednica Shuttleovih korisnika na Google+. Ako imate pitanja ili trebate pomoć, to je najbolje mjesto za provjeriti.</string>
+    <string name="pref_title_community">Pronađite pomoć</string>
+    <string name="pref_summary_community">Postoji vrlo aktivna zajednica Shuttleovih korisnika na Google+. Ako imate pitanja ili trebate pomoć, to je najbolje mjesto za provjeriti.</string>
     <string name="pref_title_rate">Recite hvala</string>
     <string name="pref_summary_rate">Ako vam se sviđa Shuttle, molimo ostavite osvrt.</string>
     <string name="pref_title_headset_beep">Zvučni signal</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -361,8 +361,8 @@ segítségével
     <string name="pref_title_version">Verzió</string>
     <string name="pref_title_faq">GYIK</string>
     <string name="pref_summary_faq">Kérdése van? Segítségre van szüksége? GYIK a www.shuttlemusicplayer.com -on</string>
-    <string name="pref_title_gplus">Segítség</string>
-    <string name="pref_summary_gplus">Aktív közösség foglalkozik a Shuttle-el a Google+-on. Ha kérdése van vagy segítségre van szüksége ez a legjobb hely ahova fordulhat.</string>
+    <string name="pref_title_community">Segítség</string>
+    <string name="pref_summary_community">Aktív közösség foglalkozik a Shuttle-el a Google+-on. Ha kérdése van vagy segítségre van szüksége ez a legjobb hely ahova fordulhat.</string>
     <string name="pref_title_rate">Mondjon köszönetet</string>
     <string name="pref_summary_rate">Ha tetszik a Shuttle, kérem hagyjon róla egy értékelést</string>
     <!-- Settings title for ignore playlist duplicates -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -393,8 +393,8 @@
     <string name="pref_title_version">Versione</string>
     <string name="pref_title_faq">FAQ</string>
     <string name="pref_summary_faq">Hai una domanda da fare? Hai bisogno d\'aiuto? Clicca qui per leggere le FAQ su www.shuttlemusicplayer.com</string>
-    <string name="pref_title_gplus">Ottieni aiuto</string>
-    <string name="pref_summary_gplus">C\'è una comunità molto attiva di utenti di Shuttle su Google+. Se hai domande o hai bisogno di aiuto, questo è il miglior posto dove andare.</string>
+    <string name="pref_title_community">Ottieni aiuto</string>
+    <string name="pref_summary_community">C\'è una comunità molto attiva di utenti di Shuttle su Google+. Se hai domande o hai bisogno di aiuto, questo è il miglior posto dove andare.</string>
     <string name="pref_title_rate">Ringrazia</string>
     <string name="pref_summary_rate">Se ti piace utilizzare Shuttle, per favore scrivi una recensione.</string>
     <string name="pref_title_headset_beep">Bip al salto</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -377,8 +377,8 @@
     <string name="pref_title_version">バージョン</string>
     <string name="pref_title_faq">よくある質問</string>
     <string name="pref_summary_faq">質問や手助けが必要な場合はwww.shuttlemusicplayer.comでよくある質問を確認できます。</string>
-    <string name="pref_title_gplus">ヘルプを表示</string>
-    <string name="pref_summary_gplus">Google+のShuttleコミュニティーは活発に活動が行われています。ご質問や手助けが必要な場合、こちらを利用することをお勧めします。</string>
+    <string name="pref_title_community">ヘルプを表示</string>
+    <string name="pref_summary_community">Google+のShuttleコミュニティーは活発に活動が行われています。ご質問や手助けが必要な場合、こちらを利用することをお勧めします。</string>
     <string name="pref_title_rate">お礼のメッセージを送信</string>
     <string name="pref_summary_rate">Shuttleが気に入りましたら是非レビューをお願いします。</string>
     <string name="pref_title_headset_beep">スキップしたらビープ音を鳴らす</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -375,8 +375,8 @@
     <string name="pref_title_version">버전</string>
     <string name="pref_title_faq">FAQ</string>
     <string name="pref_summary_faq">질문이 있거나 도움이 필요하십니까? 여기를 누르시면 www.shuttlemusicplayer.com의 FAQ 페이지로 이동합니다</string>
-    <string name="pref_title_gplus">지원 요청</string>
-    <string name="pref_summary_gplus">Google+의 Shuttle 사용자 커뮤니티입니다. 매우 활성화되어 있어 도움이 필요할 때 가장 좋은 곳입니다.</string>
+    <string name="pref_title_community">지원 요청</string>
+    <string name="pref_summary_community">Google+의 Shuttle 사용자 커뮤니티입니다. 매우 활성화되어 있어 도움이 필요할 때 가장 좋은 곳입니다.</string>
     <string name="pref_title_rate">감사 표하기</string>
     <string name="pref_summary_rate">Shuttle이 마음에 드신다면 리뷰를 남겨 주세요.</string>
     <string name="pref_title_headset_beep">건너뛸 때 비프음</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -382,8 +382,8 @@ Indien uitgeschakeld wordt het Shuttle-icoon als plaatshouder gebruikt</string>
     <string name="pref_title_version">Versie</string>
     <string name="pref_title_faq">FAQ</string>
     <string name="pref_summary_faq">Heb je een vraag of hulp nodig? Klik hier om de FAQ te zien op www.shuttlemusicplayer.com</string>
-    <string name="pref_title_gplus">Hulp krijgen</string>
-    <string name="pref_summary_gplus">Er is een actieve gemeenschap van Shuttle-gebruikers op Google+. Als je vragen hebt of hulp nodig hebt, is dit de beste plek om naar toe te gaan.</string>
+    <string name="pref_title_community">Hulp krijgen</string>
+    <string name="pref_summary_community">Er is een actieve gemeenschap van Shuttle-gebruikers op Google+. Als je vragen hebt of hulp nodig hebt, is dit de beste plek om naar toe te gaan.</string>
     <string name="pref_title_rate">Zeg bedankt</string>
     <string name="pref_summary_rate">Als je Shuttle leuk vindt, overweeg dan om een beoordeling achter te laten.</string>
     <string name="pref_title_headset_beep">Beep bij skippen</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -382,8 +382,8 @@ Po wyłączeniu, jako obraz zastępczy będzie używana ikona programu.</string>
     <string name="pref_title_version">Wersja</string>
     <string name="pref_title_faq">Wyświetl pytania</string>
     <string name="pref_summary_faq">Przechodzi do sekcji najczęstszych pytań na stronie www.shuttlemusicplayer.com</string>
-    <string name="pref_title_gplus">Uzyskaj pomoc</string>
-    <string name="pref_summary_gplus">W społeczności Google+ jest bardzo aktywna grupa użytkowników odtwarzacza Shuttle. Jest to najlepsze miejsce, aby uzyskać poszukiwaną odpowiedź lub pomoc.</string>
+    <string name="pref_title_community">Uzyskaj pomoc</string>
+    <string name="pref_summary_community">W społeczności Google+ jest bardzo aktywna grupa użytkowników odtwarzacza Shuttle. Jest to najlepsze miejsce, aby uzyskać poszukiwaną odpowiedź lub pomoc.</string>
     <string name="pref_title_rate">Podziękuj</string>
     <string name="pref_summary_rate">Umożliwia zostawienie opinii na temat programu.</string>
     <string name="pref_title_headset_beep">Sygnał pomijania</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -383,8 +383,8 @@ Se estiver desmarcado, o ícone do Shuttle será usado como uma capa</string>
     <string name="pref_title_version">Versão</string>
     <string name="pref_title_faq">Perguntas frequentes</string>
     <string name="pref_summary_faq">Tem alguma pergunta? Precisa de ajuda? Clique aqui para ver as perguntas frequentes em www.shuttlemusicplayer.com</string>
-    <string name="pref_title_gplus">Pedir ajuda</string>
-    <string name="pref_summary_gplus">Há uma comunidade bastante ativa de usuários do Shuttle no Google+. Se você tiver perguntas ou precisa de ajuda, lá é o melhor lugar para ir.</string>
+    <string name="pref_title_community">Pedir ajuda</string>
+    <string name="pref_summary_community">Há uma comunidade bastante ativa de usuários do Shuttle no Google+. Se você tiver perguntas ou precisa de ajuda, lá é o melhor lugar para ir.</string>
     <string name="pref_title_rate">Diga obrigado</string>
     <string name="pref_summary_rate">Se você gosta do Shuttle, considere deixar um comentário.</string>
     <string name="pref_title_headset_beep">Fazer Beep ao Pular</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -350,8 +350,8 @@
     <string name="pref_title_version">Versiunea</string>
     <string name="pref_title_faq">Întrebări Frecvente</string>
     <string name="pref_summary_faq">Ai o întrebare? Ai nevoie de ajutor? Click aici pentru a vedea întrebările frecvente pe www.shuttlemusicplayer.com</string>
-    <string name="pref_title_gplus">Ajutor</string>
-    <string name="pref_summary_gplus">Aceasta este o comunitate foarte activă de utilizatori Shuttle pe Google+. Dacă ai întrebari sau ai nevoie de ajutor, acesta este cel mai bun loc.</string>
+    <string name="pref_title_community">Ajutor</string>
+    <string name="pref_summary_community">Aceasta este o comunitate foarte activă de utilizatori Shuttle pe Google+. Dacă ai întrebari sau ai nevoie de ajutor, acesta este cel mai bun loc.</string>
     <string name="pref_title_rate">Spune mulțumesc</string>
     <string name="pref_summary_rate">Dacă îți place Shuttle, lasă o recenzie.</string>
     <!-- Settings title for ignore playlist duplicates -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -387,8 +387,8 @@
     <string name="pref_title_version">Версия</string>
     <string name="pref_title_faq">Часто задаваемые вопросы</string>
     <string name="pref_summary_faq">Есть вопросы? Нужна помощь? Нажмите сюда для просмотра FAQ на www.shuttlemusicplayer.com</string>
-    <string name="pref_title_gplus">Получить помощь</string>
-    <string name="pref_summary_gplus">На Google+ есть очень активное сообщество пользователей Shuttle. Если Вы имеете вопросы или нуждаетесь в помощи, это лучшее место, куда следует обратиться.</string>
+    <string name="pref_title_community">Получить помощь</string>
+    <string name="pref_summary_community">На Google+ есть очень активное сообщество пользователей Shuttle. Если Вы имеете вопросы или нуждаетесь в помощи, это лучшее место, куда следует обратиться.</string>
     <string name="pref_title_rate">Поблагодарить</string>
     <string name="pref_summary_rate">Если Вам нравится Shuttle, оставьте отзыв, пожалуйста.</string>
     <string name="pref_title_headset_beep">Звук при пропуске</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -372,8 +372,8 @@
     <string name="pref_title_version">รุ่น</string>
     <string name="pref_title_faq">คำถามที่พบบ่อย</string>
     <string name="pref_summary_faq">มีคำถาม? ต้องการความช่วยเหลือ? คลิกที่นี่เพื่อดูคำถามที่พบบ่อย @ www.shuttlemusicplayer.com</string>
-    <string name="pref_title_gplus">ขอความช่วยเหลือ</string>
-    <string name="pref_summary_gplus">ชุมชนผู้ใช้ Shuttle ในชุมชน Google+ มีการใช้งานเป็นอย่างมาก หากคุณมีคำถามหรือต้องการความช่วยเหลือนี่เป็นสถานที่ที่ดีที่สุด</string>
+    <string name="pref_title_community">ขอความช่วยเหลือ</string>
+    <string name="pref_summary_community">ชุมชนผู้ใช้ Shuttle ในชุมชน Google+ มีการใช้งานเป็นอย่างมาก หากคุณมีคำถามหรือต้องการความช่วยเหลือนี่เป็นสถานที่ที่ดีที่สุด</string>
     <string name="pref_title_rate">พูดขอบคุณ</string>
     <string name="pref_summary_rate">ถ้าคุณชอบ Shuttle โปรดพิจารณาออกความคิดเห็น</string>
     <string name="pref_title_headset_beep">เสียงเตือนเมื่อข้าม</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -383,8 +383,8 @@ Bu seçenek işaretli değilse, Shuttle simgesi kullanılacaktır.</string>
     <string name="pref_title_version">Sürüm</string>
     <string name="pref_title_faq">SSS</string>
     <string name="pref_summary_faq">Bir sorunuz mu var? Yardıma mı ihtiyacınız var? SSS leri görmek için buraya tıklayın @ www.shuttlemusicplayer.com</string>
-    <string name="pref_title_gplus">Yardım Alın</string>
-    <string name="pref_summary_gplus">Shuttle kullanıcıların çok aktif bir Google+ topluluğu vardır. Sorularınız varsa veya yardıma ihtiyacınız varsa, burası uğramanız gereken en doğru yerdir.</string>
+    <string name="pref_title_community">Yardım Alın</string>
+    <string name="pref_summary_community">Shuttle kullanıcıların çok aktif bir Google+ topluluğu vardır. Sorularınız varsa veya yardıma ihtiyacınız varsa, burası uğramanız gereken en doğru yerdir.</string>
     <string name="pref_title_rate">Teşekkür Et</string>
     <string name="pref_summary_rate">Eğer Shuttle\'ı beğendiyseniz, lütfen bir yorum bırakmayı düşünün.</string>
     <string name="pref_title_headset_beep">Bip Sesini Atla</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -367,8 +367,8 @@
     <string name="pref_title_version">Версія</string>
     <string name="pref_title_faq">Допомога</string>
     <string name="pref_summary_faq">Маєте питання? Потрібна допомога? Натисніть тут щоб переглянути статті \"питання-відповідь\" @ www.shuttlemusicplayer.com</string>
-    <string name="pref_title_gplus">Отримати</string>
-    <string name="pref_summary_gplus">В нас є дуже активна спільнота користувачів Shuttle в Google+. Якщо ви маєте якісь питання чи вам потрібна допомога, пишіть нам.</string>
+    <string name="pref_title_community">Отримати</string>
+    <string name="pref_summary_community">В нас є дуже активна спільнота користувачів Shuttle в Google+. Якщо ви маєте якісь питання чи вам потрібна допомога, пишіть нам.</string>
     <string name="pref_title_rate">Подякувати</string>
     <string name="pref_summary_rate">Якщо Вам подобається Shuttle, будь ласка залиште відгук</string>
     <!-- Settings title for ignore playlist duplicates -->

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -371,8 +371,8 @@
     <string name="pref_title_version">Phiên bản</string>
     <string name="pref_title_faq">FAQ</string>
     <string name="pref_summary_faq">Bạn có câu hỏi? Cần giúp dỡ? Chạm vào đây để xem FAQ @ www.shuttlemusicplayer.com</string>
-    <string name="pref_title_gplus">Nhận giúp đỡ</string>
-    <string name="pref_summary_gplus">Có một cộng đồng người dùng Shuttle rất năng động trên Google+. Nếu bạn có câu hỏi hay cần giúp đỡ gì đó, đấy chính là nơi tốt nhất.</string>
+    <string name="pref_title_community">Nhận giúp đỡ</string>
+    <string name="pref_summary_community">Có một cộng đồng người dùng Shuttle rất năng động trên Google+. Nếu bạn có câu hỏi hay cần giúp đỡ gì đó, đấy chính là nơi tốt nhất.</string>
     <string name="pref_title_rate">Nói cảm ơn</string>
     <string name="pref_summary_rate">Nếu bạn thích Shuttle, hãy xem xét để lại một đánh giá</string>
     <string name="pref_title_headset_beep">Beep khi bỏ qua</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -383,8 +383,8 @@
     <string name="pref_title_version">当前版本</string>
     <string name="pref_title_faq">常见问题</string>
     <string name="pref_summary_faq">有问题或需要协助吗？请按这里查询常见问题 www.shuttlemusicplayer.com</string>
-    <string name="pref_title_gplus">取得帮助</string>
-    <string name="pref_summary_gplus">我们在 Google+ 上有个非常活跃的 Shuttle 社群，若您有任何问题或需要协助，您可拜访这个好地方</string>
+    <string name="pref_title_community">取得帮助</string>
+    <string name="pref_summary_community">我们在 Google+ 上有个非常活跃的 Shuttle 社群，若您有任何问题或需要协助，您可拜访这个好地方</string>
     <string name="pref_title_rate">感谢评分</string>
     <string name="pref_summary_rate">若您喜欢 Shuttle，您可给予评价</string>
     <string name="pref_title_headset_beep">耳机跳歌提醒</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -380,8 +380,8 @@
     <string name="pref_title_version">版本</string>
     <string name="pref_title_faq">常見問題</string>
     <string name="pref_summary_faq">有問題或需要協助嗎？請按這裡查詢常見問題 www.shuttlemusicplayer.com</string>
-    <string name="pref_title_gplus">取得支援</string>
-    <string name="pref_summary_gplus">我們在 Google+ 上有個非常活躍的 Shuttle 社群，若您有任何問題或需要協助，您可拜訪這個好地方</string>
+    <string name="pref_title_community">取得支援</string>
+    <string name="pref_summary_community">我們在 Google+ 上有個非常活躍的 Shuttle 社群，若您有任何問題或需要協助，您可拜訪這個好地方</string>
     <string name="pref_title_rate">感謝與評分</string>
     <string name="pref_summary_rate">若您喜歡 Shuttle，您可給予評價</string>
     <string name="pref_title_headset_beep">略過提醒</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -421,7 +421,7 @@
     <string name="pref_title_faq">FAQ</string>
     <string name="pref_summary_faq">Have a question? Need help? Click here to view the FAQ @ www.shuttlemusicplayer.com</string>
     <string name="pref_title_community">Get Help</string>
-    <string name="pref_summary_community">There is a very active community of Shuttle users on Google+. If you have questions or need help, this is the best place to go.</string>
+    <string name="pref_summary_community">There is a very active community of Shuttle users on Discord. If you have questions or need help, this is the best place to go.</string>
     <string name="pref_title_rate">Say Thanks</string>
     <string name="pref_summary_rate">If you like Shuttle, please consider leaving a review.</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -420,8 +420,8 @@
     <string name="pref_title_version">Version</string>
     <string name="pref_title_faq">FAQ</string>
     <string name="pref_summary_faq">Have a question? Need help? Click here to view the FAQ @ www.shuttlemusicplayer.com</string>
-    <string name="pref_title_gplus">Get Help</string>
-    <string name="pref_summary_gplus">There is a very active community of Shuttle users on Google+. If you have questions or need help, this is the best place to go.</string>
+    <string name="pref_title_community">Get Help</string>
+    <string name="pref_summary_community">There is a very active community of Shuttle users on Google+. If you have questions or need help, this is the best place to go.</string>
     <string name="pref_title_rate">Say Thanks</string>
     <string name="pref_summary_rate">If you like Shuttle, please consider leaving a review.</string>
 

--- a/app/src/main/res/xml/settings_support.xml
+++ b/app/src/main/res/xml/settings_support.xml
@@ -20,8 +20,8 @@
 
         <android.support.v7.preference.Preference
             android:key="pref_help"
-            android:summary="@string/pref_summary_gplus"
-            android:title="@string/pref_title_gplus"/>
+            android:summary="@string/pref_summary_community"
+            android:title="@string/pref_title_community"/>
 
         <android.support.v7.preference.Preference
             android:key="pref_rate"


### PR DESCRIPTION
Resolves #471 The support community moved to Discord after Google+ was shut down, but the in-app link pointed to the dead G+ link

The variable names were refactored to a more general sense.
The string in translated languages have not been refactored as it may break the context.