### PR TITLE
Group albums into artists regardless of artist name capitalisation

### DIFF
--- a/app/src/main/java/com/simplecity/amp_library/utils/Operators.java
+++ b/app/src/main/java/com/simplecity/amp_library/utils/Operators.java
@@ -67,7 +67,7 @@ public class Operators {
             AlbumArtist albumArtist = album.getAlbumArtist();
 
             //Check if there's already an equivalent album-artist in our albumArtistMap
-            AlbumArtist oldAlbumArtist = albumArtistMap.get(albumArtist.name);
+            AlbumArtist oldAlbumArtist = albumArtistMap.get(albumArtist.name.toLowerCase());
             if (oldAlbumArtist != null) {
 
                 //Add this album to the album artist's albums
@@ -75,7 +75,7 @@ public class Operators {
                     oldAlbumArtist.albums.add(album);
                 }
             } else {
-                albumArtistMap.put(albumArtist.name, albumArtist);
+                albumArtistMap.put(albumArtist.name.toLowerCase(), albumArtist);
             }
         }
 

--- a/buildSrc/src/main/kotlin/dependencies/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/dependencies/Dependencies.kt
@@ -11,7 +11,7 @@ object Dependencies {
         const val crashlytics = "2.9.9"
         const val dashClockApi = "2.0.0"
         const val fastScroll = "1.0.20"
-        const val glide = "3.8.0-SNAPSHOT"
+        const val glide = "3.8.0"
         const val glideOkhttp = "1.4.0@aar"
         const val materialDialogs = "0.9.6.0"
         const val permiso = "0.3.0"


### PR DESCRIPTION
This discards capitalisation when making a list of AlbumArtists, stopping it from separating inconsistent artists into several AlbumArtists. It will still show the correct capitalisation on the display.
I also included the update to the glide version that was causing the build to fail.
closes #497 closes #491 