### PR TITLE
Fix slow library loading with a lot of inclusions or exclusions

### DIFF
--- a/app/src/main/java/com/simplecity/amp_library/data/SongsRepository.kt
+++ b/app/src/main/java/com/simplecity/amp_library/data/SongsRepository.kt
@@ -28,6 +28,7 @@ import io.reactivex.functions.Function3
 import io.reactivex.schedulers.Schedulers
 import java.util.ArrayList
 import java.util.Arrays
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -194,15 +195,21 @@ open class SongsRepository @Inject constructor(
 
                     // Filter out excluded paths
                     if (!exclItems.isEmpty()) {
+                        val exclSongPaths = exclItems
+                            .map { it.path.toLowerCase(Locale.ROOT) }
+                            .toHashSet()
                         result = songs
-                            .filterNot { song -> exclItems.any { exclItem -> StringUtils.containsIgnoreCase(song.path, exclItem.path) } }
+                            .filterNot { it.path.toLowerCase(Locale.ROOT) in exclSongPaths }
                             .toList()
                     }
 
                     // Filter out non-included paths
                     if (!inclItems.isEmpty()) {
+                        val inclSongPaths = inclItems
+                            .map { it.path.toLowerCase(Locale.ROOT) }
+                            .toHashSet()
                         result = result
-                            .filter { song -> inclItems.any { inclItem -> StringUtils.containsIgnoreCase(song.path, inclItem.path) } }
+                            .filter { it.path.toLowerCase(Locale.ROOT) in inclSongPaths }
                             .toList()
                     }
 


### PR DESCRIPTION
This closes #534 - the library loads very slowly when there are entries in the blacklist. Seems that I found the issue - there was a hidden `O(N^2)` loop in the incl/excl filtering algorithm.
I converted the include/exclude path lists to hash sets that have fast member checks and this seems to solve the performance problems:
```
[(no exclusions) + app start..]
2021-08-24 21:00:50.683 15138-15138/com.simplecity.amp_pro.debug I/PERF: Requested album load
2021-08-24 21:00:51.159 15138-15205/com.simplecity.amp_pro.debug I/PERF: Albums loaded 295 in 476ms
[app restart..]
2021-08-24 21:01:14.905 15356-15356/com.simplecity.amp_pro.debug I/PERF: Requested album load
2021-08-24 21:01:15.357 15356-15434/com.simplecity.amp_pro.debug I/PERF: Albums loaded 295 in 451ms
[blacklist spotify cache folders + app restart..]
2021-08-24 21:02:02.308 15773-15773/com.simplecity.amp_pro.debug I/PERF: Requested album load
2021-08-24 21:02:02.677 15773-15839/com.simplecity.amp_pro.debug I/PERF: Albums loaded 188 in 368ms
[app restart..]
2021-08-24 21:02:24.031 16003-16003/com.simplecity.amp_pro.debug I/PERF: Requested album load
2021-08-24 21:02:24.455 16003-16108/com.simplecity.amp_pro.debug I/PERF: Albums loaded 188 in 423ms
```

Now if I'm not mistaken, this should now be O(N) and scale a little better.